### PR TITLE
Update to support latest vsomeip and Zenoh transports

### DIFF
--- a/.github/workflows/bundled-lint-and-test.yaml
+++ b/.github/workflows/bundled-lint-and-test.yaml
@@ -63,15 +63,21 @@ jobs:
           rustup show
           rustup component add rustfmt clippy
 
-      - name: Build the project
+      - name: Build the project without Zenoh & vsomeip transports
         working-directory: ${{github.workspace}}
         run: cargo build
+      - name: cargo clippy without Zenoh & vsomeip transports
+        working-directory: ${{github.workspace}}
+        run: cargo clippy --all-targets -- -W warnings -D warnings
+      - name: Build the project with Zenoh & vsomeip transports (and thus streamer references)
+        working-directory: ${{github.workspace}}
+        run: cargo build --features vsomeip-transport,bundled-vsomeip,zenoh-transport
+      - name: cargo clippy with Zenoh & vsomeip transports (and thus streamer references)
+        working-directory: ${{github.workspace}}
+        run: cargo clippy --features vsomeip-transport,bundled-vsomeip,zenoh-transport --all-targets -- -W warnings -D warnings
       - name: cargo fmt
         working-directory: ${{github.workspace}}
         run: cargo fmt -- --check
-      - name: cargo clippy
-        working-directory: ${{github.workspace}}
-        run: cargo clippy --all-targets -- -W warnings -D warnings
 
   test:
     name: Test

--- a/.github/workflows/unbundled-lint-and-test.yaml
+++ b/.github/workflows/unbundled-lint-and-test.yaml
@@ -160,15 +160,21 @@ jobs:
           rustup show
           rustup component add rustfmt clippy
 
-      - name: Build the project
+      - name: Build the project without Zenoh & vsomeip transports
         working-directory: ${{github.workspace}}
-        run: cargo build --no-default-features
+        run: cargo build
+      - name: cargo clippy without Zenoh & vsomeip transports
+        working-directory: ${{github.workspace}}
+        run: cargo clippy --all-targets -- -W warnings -D warnings
+      - name: Build the project with Zenoh & vsomeip transports (and thus streamer references)
+        working-directory: ${{github.workspace}}
+        run: cargo build --features vsomeip-transport,zenoh-transport
+      - name: cargo clippy with Zenoh & vsomeip transports (and thus streamer references)
+        working-directory: ${{github.workspace}}
+        run: cargo clippy --features vsomeip-transport,zenoh-transport --all-targets -- -W warnings -D warnings
       - name: cargo fmt
         working-directory: ${{github.workspace}}
         run: cargo fmt -- --check
-      - name: cargo clippy
-        working-directory: ${{github.workspace}}
-        run: cargo clippy --no-default-features --all-targets -- -W warnings -D warnings
 
   test:
     name: Test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,18 +4,18 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.22.0"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
  "gimli",
 ]
 
 [[package]]
-name = "adler"
-version = "1.0.2"
+name = "adler2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "aes"
@@ -73,9 +73,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.15"
+version = "0.6.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
+checksum = "23a1e53f0f5d86382dafe1cf314783b2044280f406e7e1506368220ad11b1338"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -88,43 +88,43 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.8"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.4"
+version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
+checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
 dependencies = [
  "anstyle",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.86"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
+checksum = "74f37166d7d48a0284b99dd824694c26119c700b53bf0d1540cdb147dbdaaf13"
 
 [[package]]
 name = "aquamarine"
@@ -169,7 +169,7 @@ checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.86",
  "synstructure",
 ]
 
@@ -181,7 +181,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -231,14 +231,14 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7ebdfa2ebdab6b1760375fa7d6f382b9f486eac35fc994625a00e89280bdbb7"
+checksum = "30ca9a001c1e8ba5149f91a74362376cc6bc5b919d92d988668657bd570bdcec"
 dependencies = [
  "async-task",
  "concurrent-queue",
- "fastrand 2.1.0",
- "futures-lite 2.3.0",
+ "fastrand 2.1.1",
+ "futures-lite 2.4.0",
  "slab",
 ]
 
@@ -253,9 +253,8 @@ dependencies = [
  "async-io 2.3.4",
  "async-lock 3.4.0",
  "blocking",
- "futures-lite 2.3.0",
+ "futures-lite 2.4.0",
  "once_cell",
- "tokio",
 ]
 
 [[package]]
@@ -288,10 +287,10 @@ dependencies = [
  "cfg-if",
  "concurrent-queue",
  "futures-io",
- "futures-lite 2.3.0",
+ "futures-lite 2.4.0",
  "parking",
  "polling 3.7.3",
- "rustix 0.38.34",
+ "rustix 0.38.38",
  "slab",
  "tracing",
  "windows-sys 0.59.0",
@@ -330,7 +329,7 @@ dependencies = [
  "cfg-if",
  "event-listener 3.1.0",
  "futures-lite 1.13.0",
- "rustix 0.38.34",
+ "rustix 0.38.38",
  "windows-sys 0.48.0",
 ]
 
@@ -346,7 +345,7 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix 0.38.34",
+ "rustix 0.38.38",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.59.0",
@@ -388,13 +387,13 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.81"
+version = "0.1.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
+checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -416,9 +415,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "autocxx"
@@ -452,7 +451,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.74",
+ "syn 2.0.86",
  "which",
 ]
 
@@ -465,7 +464,7 @@ dependencies = [
  "autocxx-engine",
  "env_logger 0.9.3",
  "indexmap 1.9.3",
- "syn 2.0.74",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -492,7 +491,7 @@ dependencies = [
  "rustversion",
  "serde_json",
  "strum_macros",
- "syn 2.0.74",
+ "syn 2.0.86",
  "tempfile",
  "thiserror",
  "version_check",
@@ -508,7 +507,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -525,23 +524,23 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn 2.0.74",
+ "syn 2.0.86",
  "thiserror",
 ]
 
 [[package]]
 name = "backtrace"
-version = "0.3.73"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
+checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
 dependencies = [
  "addr2line",
- "cc",
  "cfg-if",
  "libc",
  "miniz_oxide",
  "object",
  "rustc-demangle",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -593,16 +592,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitmask-enum"
-version = "2.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afb15541e888071f64592c0b4364fdff21b7cb0a247f984296699351963a8721"
-dependencies = [
- "quote",
- "syn 2.0.74",
-]
-
-[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -620,7 +609,7 @@ dependencies = [
  "async-channel 2.3.1",
  "async-task",
  "futures-io",
- "futures-lite 2.3.0",
+ "futures-lite 2.4.0",
  "piper",
 ]
 
@@ -638,9 +627,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
+checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
 
 [[package]]
 name = "cache-padded"
@@ -650,9 +639,9 @@ checksum = "981520c98f422fcc584dc1a95c334e6953900b9106bc47a9839b81790009eb21"
 
 [[package]]
 name = "cc"
-version = "1.1.12"
+version = "1.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68064e60dbf1f17005c2fde4d07c16d8baa506fd7ffed8ccab702d93617975c7"
+checksum = "c2e7962b54006dcfcc61cb72735f4d89bb97061dd6a7ed882ec6b8ee53714c6f"
 dependencies = [
  "shlex",
 ]
@@ -677,6 +666,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -715,9 +710,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.15"
+version = "4.5.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d8838454fda655dafd3accb2b6e2bea645b9e4078abe84a22ceb947235c5cc"
+checksum = "b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -725,9 +720,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.15"
+version = "4.5.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216aec2b177652e3846684cbfe25c9964d18ec45234f0f5da5157b207ed1aab6"
+checksum = "19bc80abd44e4bed93ca373a0704ccbd1b710dc5749406201bb018272808dc54"
 dependencies = [
  "anstream",
  "anstyle",
@@ -737,14 +732,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.13"
+version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
+checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -774,9 +769,9 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "combine"
@@ -805,29 +800,23 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "const_format"
-version = "0.2.32"
+version = "0.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a214c7af3d04997541b18d432afaff4c455e79e2029079647e72fc2bd27673"
+checksum = "50c655d81ff1114fb0dcdea9225ea9f0cc712a6f8d189378e82bdf62a473a64b"
 dependencies = [
  "const_format_proc_macros",
 ]
 
 [[package]]
 name = "const_format_proc_macros"
-version = "0.2.32"
+version = "0.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f6ff08fd20f4f299298a28e2dfa8a8ba1036e6cd2460ac1de7b425d76f2500"
+checksum = "eff1a44b93f47b1bac19a27932f5c591e43d1ba357ee4f61526c8a25603f0eb1"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
 ]
-
-[[package]]
-name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "core-foundation"
@@ -847,9 +836,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51e852e6dc9a5bed1fae92dd2375037bf2b768725bf3be87811edee3249d09ad"
+checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
 dependencies = [
  "libc",
 ]
@@ -900,9 +889,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.126"
+version = "1.0.129"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c4eae4b7fc8dcb0032eb3b1beee46b38d371cdeaf2d0c64b9944f6f69ad7755"
+checksum = "cbdc8cca144dce1c4981b5c9ab748761619979e515c3d53b5df385c677d1d007"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -912,9 +901,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.126"
+version = "1.0.129"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c822bf7fb755d97328d6c337120b6f843678178751cba33c9da25cf522272e0"
+checksum = "c5764c3142ab44fcf857101d12c0ddf09c34499900557c764f5ad0597159d1fc"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -922,36 +911,36 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.74",
+ "syn 2.0.86",
 ]
 
 [[package]]
 name = "cxx-gen"
-version = "0.7.126"
+version = "0.7.129"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e8ba19208b722eb93d9436b6e8de8dd65a168212f25d5b7e6607ad317cb0ec3"
+checksum = "efca6ed5e98eb15f076dde7604398cda57c6d3ede0e13b4185aa2d212e1e528e"
 dependencies = [
  "codespan-reporting",
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.86",
 ]
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.126"
+version = "1.0.129"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719d6197dc016c88744aff3c0d0340a01ecce12e8939fc282e7c8f583ee64bc6"
+checksum = "d422aff542b4fa28c2ce8e5cc202d42dbf24702345c1fba3087b2d3f8a1b90ff"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.126"
+version = "1.0.129"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35de3b547387863c8f82013c4f79f1c2162edee956383e4089e1d04c18c4f16c"
+checksum = "a1719100f31492cd6adeeab9a0f46cdbc846e615fdb66d7b398aa46ec7fdd06f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -996,15 +985,22 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.99.18"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
+checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
 dependencies = [
- "convert_case",
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
  "proc-macro2",
  "quote",
- "rustc_version",
- "syn 2.0.74",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -1048,7 +1044,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -1065,9 +1061,9 @@ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.34"
+version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
 ]
@@ -1183,9 +1179,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
+checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
 name = "fixedbitset"
@@ -1195,9 +1191,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flume"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1237,9 +1233,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1252,9 +1248,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1262,15 +1258,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1279,9 +1275,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-lite"
@@ -1300,11 +1296,11 @@ dependencies = [
 
 [[package]]
 name = "futures-lite"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52527eb5074e35e9339c6b4e8d12600c7128b68fb25dcb9fa9dec18f7c25f3a5"
+checksum = "3f1fa2f9765705486b33fd2acf1577f8ec449c2ba1f318ae5447697b7c08d210"
 dependencies = [
- "fastrand 2.1.0",
+ "fastrand 2.1.1",
  "futures-core",
  "futures-io",
  "parking",
@@ -1313,32 +1309,32 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.86",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-util"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1377,9 +1373,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.29.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "git-version"
@@ -1398,7 +1394,7 @@ checksum = "53010ccb100b96a67bc32c0175f0ed1426b31b655d562898e57325f81c023ac0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -1421,9 +1417,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa82e28a107a8cc405f0839610bdc9b15f1e25ec7d696aa5cf173edbcb1486ab"
+checksum = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1431,18 +1427,12 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.4.0",
+ "indexmap 2.6.0",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
 ]
-
-[[package]]
-name = "half"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
 
 [[package]]
 name = "hashbrown"
@@ -1459,6 +1449,12 @@ dependencies = [
  "ahash",
  "allocator-api2",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
 
 [[package]]
 name = "heck"
@@ -1558,9 +1554,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.9.4"
+version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
+checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
 
 [[package]]
 name = "humantime"
@@ -1570,9 +1566,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
+checksum = "bbbff0a806a4728c99295b254c8838933b5b082d75e3cb70c8dab21fdfbcfa9a"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1590,9 +1586,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.2"
+version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
+checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
 dependencies = [
  "futures-util",
  "http",
@@ -1623,9 +1619,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.7"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cde7055719c54e36e95e8719f95883f22072a48ede39db7fc17a4e1d5281e9b9"
+checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1636,16 +1632,15 @@ dependencies = [
  "pin-project-lite",
  "socket2 0.5.7",
  "tokio",
- "tower",
  "tower-service",
  "tracing",
 ]
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.60"
+version = "0.1.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
+checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -1687,12 +1682,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.4.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93ead53efc7ea8ed3cfb0c79fc8023fbb782a5432b52830b6518941cebe6505c"
+checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.0",
 ]
 
 [[package]]
@@ -1724,13 +1719,14 @@ name = "integration-test-utils"
 version = "0.1.0"
 dependencies = [
  "async-broadcast",
- "async-std",
  "async-trait",
  "env_logger 0.10.2",
  "futures",
  "log",
  "rand",
  "serde_json",
+ "tokio",
+ "tokio-condvar",
  "up-rust",
  "up-streamer",
  "uuid",
@@ -1749,9 +1745,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.9.0"
+version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
+checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
 
 [[package]]
 name = "ipnetwork"
@@ -1786,12 +1782,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
-name = "iter-read"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c397ca3ea05ad509c4ec451fea28b4771236a376ca1c69fd5143aae0cf8f93c4"
-
-[[package]]
 name = "itertools"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1805,15 +1795,6 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
@@ -1855,9 +1836,9 @@ checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "js-sys"
-version = "0.3.70"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
+checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1917,9 +1898,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.161"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
 
 [[package]]
 name = "libloading"
@@ -1933,9 +1914,9 @@ dependencies = [
 
 [[package]]
 name = "libm"
-version = "0.2.8"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
 name = "libredox"
@@ -2046,7 +2027,7 @@ checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -2063,11 +2044,11 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
+checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
 dependencies = [
- "adler",
+ "adler2",
 ]
 
 [[package]]
@@ -2119,12 +2100,13 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.27.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
  "bitflags 2.6.0",
  "cfg-if",
+ "cfg_aliases",
  "libc",
 ]
 
@@ -2229,33 +2211,33 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.3"
+version = "0.36.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b64972346851a39438c60b341ebc01bba47464ae329e55cf343eb93964efd9"
+checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "oid-registry"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c958dd45046245b9c3c2547369bb634eb461670b2e7e0de552905801a648d1d"
+checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
 dependencies = [
  "asn1-rs",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "openssl"
-version = "0.10.66"
+version = "0.10.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
+checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
 dependencies = [
  "bitflags 2.6.0",
  "cfg-if",
@@ -2274,7 +2256,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -2285,9 +2267,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.103"
+version = "0.9.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
+checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
 dependencies = [
  "cc",
  "libc",
@@ -2300,15 +2282,6 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
-name = "ordered-float"
-version = "4.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a91171844676f8c7990ce64959210cd2eaef32c2612c50f9fae9f8aaa6065a6"
-dependencies = [
- "num-traits",
-]
 
 [[package]]
 name = "outref"
@@ -2330,9 +2303,9 @@ checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
 name = "parking"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "paste"
@@ -2363,9 +2336,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.11"
+version = "2.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd53dff83f26735fdc1ca837098ccf133605d794cdae66acfc2bfac3ec809d95"
+checksum = "879952a81a83930934cbf1786752d6dedc3b1f29e8f8fb2ad1d0a36f377cf442"
 dependencies = [
  "memchr",
  "thiserror",
@@ -2374,9 +2347,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.11"
+version = "2.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a548d2beca6773b1c244554d36fcf8548a8a58e74156968211567250e48e49a"
+checksum = "d214365f632b123a47fd913301e14c946c61d1c183ee245fa76eb752e59a02dd"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2384,22 +2357,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.11"
+version = "2.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c93a82e8d145725dcbaf44e5ea887c8a869efdcc28706df2d08c69e17077183"
+checksum = "eb55586734301717aea2ac313f50b2eb8f60d2fc3dc01d190eefa2e625f60c4e"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.86",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.7.11"
+version = "2.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a941429fea7e08bedec25e4f6785b6ffaacc6b755da98df5ef3e7dcf4a124c4f"
+checksum = "b75da2a70cf4d9cb76833c990ac9cd3923c9a8905a8929789ce347c84564d03d"
 dependencies = [
  "once_cell",
  "pest",
@@ -2413,7 +2386,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.4.0",
+ "indexmap 2.6.0",
 ]
 
 [[package]]
@@ -2446,7 +2419,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -2459,30 +2432,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "pin-project"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.74",
-]
-
-[[package]]
 name = "pin-project-lite"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
 
 [[package]]
 name = "pin-utils"
@@ -2497,7 +2450,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
 dependencies = [
  "atomic-waker",
- "fastrand 2.1.0",
+ "fastrand 2.1.1",
  "futures-io",
 ]
 
@@ -2524,9 +2477,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "pnet_base"
@@ -2586,7 +2539,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi 0.4.0",
  "pin-project-lite",
- "rustix 0.38.34",
+ "rustix 0.38.38",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -2608,12 +2561,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.20"
+version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
+checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
 dependencies = [
  "proc-macro2",
- "syn 2.0.74",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -2642,50 +2595,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "prost"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
-dependencies = [
- "bytes",
- "prost-derive",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
-dependencies = [
- "anyhow",
- "itertools 0.12.1",
- "proc-macro2",
- "quote",
- "syn 2.0.74",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
-dependencies = [
- "prost",
-]
-
-[[package]]
 name = "protobuf"
-version = "3.5.0"
+version = "3.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df67496db1a89596beaced1579212e9b7c53c22dca1d9745de00ead76573d514"
+checksum = "a3a7c64d9bf75b1b8d981124c14c179074e8caa7dfe7b6a12e6222ddcd0c8f72"
 dependencies = [
  "bytes",
  "once_cell",
@@ -2695,9 +2616,9 @@ dependencies = [
 
 [[package]]
 name = "protobuf-codegen"
-version = "3.5.0"
+version = "3.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eab09155fad2d39333d3796f67845d43e29b266eea74f7bc93f153f707f126dc"
+checksum = "e26b833f144769a30e04b1db0146b2aaa53fd2fd83acf10a6b5f996606c18144"
 dependencies = [
  "anyhow",
  "once_cell",
@@ -2710,12 +2631,12 @@ dependencies = [
 
 [[package]]
 name = "protobuf-parse"
-version = "3.5.0"
+version = "3.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a16027030d4ec33e423385f73bb559821827e9ec18c50e7874e4d6de5a4e96f"
+checksum = "322330e133eab455718444b4e033ebfac7c6528972c784fcde28d2cc783c6257"
 dependencies = [
  "anyhow",
- "indexmap 2.4.0",
+ "indexmap 2.6.0",
  "log",
  "protobuf",
  "protobuf-support",
@@ -2726,68 +2647,75 @@ dependencies = [
 
 [[package]]
 name = "protobuf-support"
-version = "3.5.0"
+version = "3.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e2d30ab1878b2e72d1e2fc23ff5517799c9929e2cf81a8516f9f4dcf2b9cf3"
+checksum = "b088fd20b938a875ea00843b6faf48579462630015c3788d397ad6a786663252"
 dependencies = [
  "thiserror",
 ]
 
 [[package]]
 name = "protoc-bin-vendored"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "005ca8623e5633e298ad1f917d8be0a44bcf406bf3cde3b80e63003e49a3f27d"
+checksum = "dd89a830d0eab2502c81a9b8226d446a52998bb78e5e33cb2637c0cdd6068d99"
 dependencies = [
  "protoc-bin-vendored-linux-aarch_64",
  "protoc-bin-vendored-linux-ppcle_64",
  "protoc-bin-vendored-linux-x86_32",
  "protoc-bin-vendored-linux-x86_64",
+ "protoc-bin-vendored-macos-aarch_64",
  "protoc-bin-vendored-macos-x86_64",
  "protoc-bin-vendored-win32",
 ]
 
 [[package]]
 name = "protoc-bin-vendored-linux-aarch_64"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fb9fc9cce84c8694b6ea01cc6296617b288b703719b725b8c9c65f7c5874435"
+checksum = "f563627339f1653ea1453dfbcb4398a7369b768925eb14499457aeaa45afe22c"
 
 [[package]]
 name = "protoc-bin-vendored-linux-ppcle_64"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d2a07dcf7173a04d49974930ccbfb7fd4d74df30ecfc8762cf2f895a094516"
+checksum = "5025c949a02cd3b60c02501dd0f348c16e8fff464f2a7f27db8a9732c608b746"
 
 [[package]]
 name = "protoc-bin-vendored-linux-x86_32"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54fef0b04fcacba64d1d80eed74a20356d96847da8497a59b0a0a436c9165b0"
+checksum = "9c9500ce67d132c2f3b572504088712db715755eb9adf69d55641caa2cb68a07"
 
 [[package]]
 name = "protoc-bin-vendored-linux-x86_64"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8782f2ce7d43a9a5c74ea4936f001e9e8442205c244f7a3d4286bd4c37bc924"
+checksum = "5462592380cefdc9f1f14635bcce70ba9c91c1c2464c7feb2ce564726614cc41"
+
+[[package]]
+name = "protoc-bin-vendored-macos-aarch_64"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c637745681b68b4435484543667a37606c95ddacf15e917710801a0877506030"
 
 [[package]]
 name = "protoc-bin-vendored-macos-x86_64"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5de656c7ee83f08e0ae5b81792ccfdc1d04e7876b1d9a38e6876a9e09e02537"
+checksum = "38943f3c90319d522f94a6dfd4a134ba5e36148b9506d2d9723a82ebc57c8b55"
 
 [[package]]
 name = "protoc-bin-vendored-win32"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9653c3ed92974e34c5a6e0a510864dab979760481714c172e0a34e437cb98804"
+checksum = "7dc55d7dec32ecaf61e0bd90b3d2392d721a28b95cfd23c3e176eccefbeab2f2"
 
 [[package]]
 name = "quinn"
-version = "0.11.3"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b22d8e7369034b9a7132bc2008cac12f2013c8132b45e0554e6e20e2617f2156"
+checksum = "8c7c5fdde3cdae7203427dc4f0a68fe0ed09833edc525a03456b153b79828684"
 dependencies = [
  "bytes",
  "pin-project-lite",
@@ -2803,9 +2731,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.6"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba92fb39ec7ad06ca2582c0ca834dfeadcaf06ddfc8e635c80aa7e1c05315fdd"
+checksum = "fadfaed2cd7f389d0161bb73eeb07b7b78f8691047a6f3e73caaeae55310a4a6"
 dependencies = [
  "bytes",
  "rand",
@@ -2821,22 +2749,23 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.4"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bffec3605b73c6f1754535084a85229fa8a30f86014e6c81aeec4abb68b0285"
+checksum = "e346e016eacfff12233c243718197ca12f148c84e1e84268a896699b41c71780"
 dependencies = [
+ "cfg_aliases",
  "libc",
  "once_cell",
  "socket2 0.5.7",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -2893,9 +2822,9 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom",
  "libredox",
@@ -2904,14 +2833,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.6"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.7",
- "regex-syntax 0.8.4",
+ "regex-automata 0.4.8",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -2925,13 +2854,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.4",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -2942,15 +2871,15 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.12.5"
+version = "0.12.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
+checksum = "a77c62af46e79de0a562e1a9849205ffcb7fc1238876e9bd743357570e04046f"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2987,7 +2916,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "winreg",
+ "windows-registry",
 ]
 
 [[package]]
@@ -3067,9 +2996,9 @@ checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
 
 [[package]]
 name = "rustc_version"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
 ]
@@ -3099,9 +3028,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.34"
+version = "0.38.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+checksum = "aa260229e6538e52293eeb577aabd09945a09d6d9cc0fc550ed7529056c2e32a"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
@@ -3112,9 +3041,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.12"
+version = "0.23.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044"
+checksum = "eee87ff5d9b36712a58574e12e9f0ea80f915a5b0ac518d322b24a465617925e"
 dependencies = [
  "log",
  "once_cell",
@@ -3127,9 +3056,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.7.1"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88d6d420651b496bdd98684116959239430022a115c1240e6c3993be0b15fba"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
 dependencies = [
  "openssl-probe",
  "rustls-pemfile",
@@ -3140,25 +3069,24 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "2.1.3"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "196fe16b00e106300d3e45ecfcb764fa292a535d7326a29a5875c579c7417425"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
 dependencies = [
- "base64 0.22.1",
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
+checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93bda3f493b9abe5b93b3e7e3ecde0df292f2bd28c0296b90586ee0055ff5123"
+checksum = "afbb878bdfdf63a336a5e63561b1835e7a8c91524f51621db870169eac84b490"
 dependencies = [
  "core-foundation",
  "core-foundation-sys",
@@ -3183,9 +3111,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.6"
+version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e6b52d4fda176fd835fdc55a835d4a89b8499cad995885a21149d5ad62f852e"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -3194,9 +3122,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
+checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
 
 [[package]]
 name = "ryu"
@@ -3215,11 +3143,11 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.23"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
+checksum = "01227be5826fa0690321a2ba6c5cd57a19cf3f6a09e76973b58e61de6ab9d1c1"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3244,7 +3172,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.74",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -3285,9 +3213,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.11.1"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf"
+checksum = "ea4a292869320c0272d7bc55a5a6aafaff59b4f63404a003887b679a2e05b4b6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3301,45 +3229,22 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.208"
+version = "1.0.214"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff085d2cb684faa248efb494c39b68e522822ac0de72ccf08109abde717cfb2"
+checksum = "f55c3193aca71c12ad7890f1785d2b73e1b9f63a0bbc353c08ef26fe03fc56b5"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
-name = "serde-pickle"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c762ad136a26407c6a80825813600ceeab5e613660d93d79a41f0ec877171e71"
-dependencies = [
- "byteorder",
- "iter-read",
- "num-bigint",
- "num-traits",
- "serde",
-]
-
-[[package]]
-name = "serde_cbor"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
-dependencies = [
- "half",
- "serde",
-]
-
-[[package]]
 name = "serde_derive"
-version = "1.0.208"
+version = "1.0.214"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24008e81ff7613ed8e5ba0cfaf24e2c2f1e5b8a0495711e44fcd4882fca62bcf"
+checksum = "de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -3350,14 +3255,14 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.86",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.125"
+version = "1.0.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83c8e735a073ccf5be70aa8066aa984eaf2fa000db6c8d0100ae605b366d31ed"
+checksum = "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
 dependencies = [
  "itoa",
  "memchr",
@@ -3383,7 +3288,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.4.0",
+ "indexmap 2.6.0",
  "itoa",
  "ryu",
  "serde",
@@ -3538,18 +3443,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
-name = "stop-token"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af91f480ee899ab2d9f8435bfdfc14d08a5754bd9d3fef1f1a1c23336aad6c8b"
-dependencies = [
- "async-channel 1.9.0",
- "cfg-if",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3631,9 +3524,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.74"
+version = "2.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fceb41e3d546d0bd83421d3409b1460cc7444cd389341a4c880fe7a042cb3d7"
+checksum = "e89275301d38033efb81a6e60e3497e734dfcc62571f2854bf4b16690398824c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3645,6 +3538,9 @@ name = "sync_wrapper"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -3654,25 +3550,25 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.86",
 ]
 
 [[package]]
 name = "system-configuration"
-version = "0.5.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.6.0",
  "core-foundation",
  "system-configuration-sys",
 ]
 
 [[package]]
 name = "system-configuration-sys"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3680,14 +3576,14 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.12.0"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
+checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
 dependencies = [
  "cfg-if",
- "fastrand 2.1.0",
+ "fastrand 2.1.1",
  "once_cell",
- "rustix 0.38.34",
+ "rustix 0.38.38",
  "windows-sys 0.59.0",
 ]
 
@@ -3723,22 +3619,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.63"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
+checksum = "5d171f59dbaa811dbbb1aee1e73db92ec2b122911a48e1390dfe327a821ddede"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.63"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+checksum = "b08be0f17bd307950653ce45db00cd31200d82b624b36e181337d9c7d92765b5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -3798,6 +3694,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "tls-listener"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f1d8809f604e448c7bc53a5a0e4c2a0a20ba44cb1fb407314c8eeccb92127f9"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "thiserror",
+ "tokio",
+ "tokio-rustls",
+]
+
+[[package]]
 name = "token-cell"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3808,9 +3717,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.39.2"
+version = "1.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daa4fb1bc778bd6f04cbfc4bb2d06a7396a8f299dc33ea1900cedaa316f467b1"
+checksum = "145f3413504347a2be84393cc8a7d2fb4d863b375909ea59f2158261aa258bbb"
 dependencies = [
  "backtrace",
  "bytes",
@@ -3824,6 +3733,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-condvar"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8530e402d24f6a65019baa57593f1769557c670302f493cdf8fa3dfbe4d85ac"
+dependencies = [
+ "tokio",
+]
+
+[[package]]
 name = "tokio-macros"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3831,7 +3749,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -3857,9 +3775,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.23.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6989540ced10490aaf14e6bad2e3d33728a2813310a0c71d1574304c49631cd"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
 dependencies = [
  "futures-util",
  "log",
@@ -3869,9 +3787,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
+checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3881,27 +3799,6 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
-
-[[package]]
-name = "tower"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
-dependencies = [
- "futures-core",
- "futures-util",
- "pin-project",
- "pin-project-lite",
- "tokio",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "tower-layer"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-service"
@@ -3929,7 +3826,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -3992,9 +3889,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e2e2ce1e47ed2994fd43b04c8f618008d4cabdd5ee34027cf14f9d918edd9c8"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
 dependencies = [
  "byteorder",
  "bytes",
@@ -4026,9 +3923,9 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "ucd-trie"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "uhlc"
@@ -4046,15 +3943,15 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.15"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
+checksum = "5ab17db44d7388991a428b2ee655ce0c212e862eff1768a455c58f9aad6e7893"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "unicode-linebreak"
@@ -4064,24 +3961,24 @@ checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
+checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
 dependencies = [
  "tinyvec",
 ]
 
 [[package]]
 name = "unicode-width"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.4"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -4094,12 +3991,6 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
-
-[[package]]
-name = "unwrap-infallible"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "151ac09978d3c2862c4e39b557f4eceee2cc72150bc4cb4f16abf061b6e381fb"
 
 [[package]]
 name = "unzip-n"
@@ -4138,7 +4029,6 @@ dependencies = [
 name = "up-linux-streamer-plugin"
 version = "0.1.0"
 dependencies = [
- "async-std",
  "const_format",
  "env_logger 0.10.2",
  "futures",
@@ -4162,9 +4052,9 @@ dependencies = [
 
 [[package]]
 name = "up-rust"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71293ba134ceaff1578bc42c874b031d4d74c694a0627bd22857ecc1ccc9ee1"
+checksum = "af7f283ab2b74869f69bcd5a87950b87db5110e46764af2ddae3248109f0e374"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4185,16 +4075,18 @@ name = "up-streamer"
 version = "0.1.0"
 dependencies = [
  "async-broadcast",
- "async-std",
  "async-trait",
  "chrono",
  "env_logger 0.10.2",
  "futures",
  "integration-test-utils",
+ "lazy_static",
  "log",
  "protobuf",
  "serde_json",
  "subscription-cache",
+ "tokio",
+ "tokio-condvar",
  "up-rust",
  "usubscription-static-file",
  "uuid",
@@ -4202,8 +4094,8 @@ dependencies = [
 
 [[package]]
 name = "up-transport-vsomeip"
-version = "0.1.0"
-source = "git+https://github.com/eclipse-uprotocol/up-transport-vsomeip-rust.git?tag=v0.1.0#c9d53f31c74258b66e792401a3717602a8eb725e"
+version = "0.2.0"
+source = "git+https://github.com/eclipse-uprotocol/up-transport-vsomeip-rust.git?tag=v0.3.0#d659287126120d4feb75cbcc35a5334def421f50"
 dependencies = [
  "async-trait",
  "bimap",
@@ -4225,22 +4117,15 @@ dependencies = [
 
 [[package]]
 name = "up-transport-zenoh"
-version = "0.1.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfac47863644cda35e70cc4b048db3f559df6f963a2d4099dce63932164d668f"
+checksum = "739441e501be7ea887024bcb2df2b452a362ee39d8efb0f2663fae0dc35e564c"
 dependencies = [
  "anyhow",
  "async-trait",
- "bitmask-enum",
  "bytes",
- "chrono",
- "clap",
- "crossbeam-channel",
  "lazy_static",
- "prost",
- "prost-types",
  "protobuf",
- "rand",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -4294,9 +4179,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
+checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
 dependencies = [
  "getrandom",
 ]
@@ -4343,9 +4228,9 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "value-bag"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a84c137d37ab0142f0f2ddfe332651fdbf252e7b7dbb4e67b6c1f1b2e925101"
+checksum = "3ef4c4aa54d5d05a279399bfa921ec387b7aba77caf7a682ae8d86785b8fdad2"
 
 [[package]]
 name = "vcpkg"
@@ -4374,18 +4259,18 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 [[package]]
 name = "vsomeip-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/eclipse-uprotocol/up-transport-vsomeip-rust.git?tag=v0.1.0#c9d53f31c74258b66e792401a3717602a8eb725e"
+source = "git+https://github.com/eclipse-uprotocol/up-transport-vsomeip-rust.git?tag=v0.3.0#d659287126120d4feb75cbcc35a5334def421f50"
 dependencies = [
  "proc-macro2",
  "quote",
  "rayon",
- "syn 2.0.74",
+ "syn 2.0.86",
 ]
 
 [[package]]
 name = "vsomeip-sys"
-version = "0.1.0"
-source = "git+https://github.com/eclipse-uprotocol/up-transport-vsomeip-rust.git?tag=v0.1.0#c9d53f31c74258b66e792401a3717602a8eb725e"
+version = "0.2.0"
+source = "git+https://github.com/eclipse-uprotocol/up-transport-vsomeip-rust.git?tag=v0.3.0#d659287126120d4feb75cbcc35a5334def421f50"
 dependencies = [
  "autocxx",
  "autocxx-build",
@@ -4432,9 +4317,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
+checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4443,24 +4328,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
+checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.86",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.43"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed"
+checksum = "cc7ec4f8827a71586374db3e87abdb5a2bb3a15afed140221307c3ec06b1f63b"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -4470,9 +4355,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
+checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4480,28 +4365,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
+checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.86",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
 
 [[package]]
 name = "web-sys"
-version = "0.3.70"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
+checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4509,9 +4394,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.3"
+version = "0.26.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd7c23921eeb1713a4e851530e9b9756e4fb0e89978582942612524cf09f01cd"
+checksum = "841c67bff177718f1d4dfefde8d8f0e78f9b6589319ba88312f567fc5841a958"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -4525,7 +4410,7 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix 0.38.34",
+ "rustix 0.38.38",
 ]
 
 [[package]]
@@ -4565,6 +4450,36 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+dependencies = [
+ "windows-result",
+ "windows-strings",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result",
  "windows-targets 0.52.6",
 ]
 
@@ -4717,16 +4632,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "winreg"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "x509-parser"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4745,49 +4650,38 @@ dependencies = [
 
 [[package]]
 name = "zenoh"
-version = "1.0.0-alpha.6"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4327cb0cfde8016990c132a573bf14394d732e5460c95eb7eaf5d52a83c357cb"
+checksum = "b28b1ce69136eba7567e5ea5c9f37aa0c7cced2673bdc3c1dd7c3c1a2ecb0d21"
 dependencies = [
  "ahash",
  "async-trait",
- "base64 0.22.1",
  "bytes",
- "event-listener 5.3.1",
  "flume",
- "form_urlencoded",
  "futures",
  "git-version",
  "itertools 0.13.0",
+ "json5",
  "lazy_static",
  "once_cell",
- "ordered-float",
  "paste",
  "petgraph",
  "phf",
  "rand",
- "regex",
  "rustc_version",
  "serde",
- "serde-pickle",
- "serde_cbor",
  "serde_json",
- "serde_yaml",
  "socket2 0.5.7",
- "stop-token",
  "tokio",
  "tokio-util",
  "tracing",
  "uhlc",
- "unwrap-infallible",
- "uuid",
  "vec_map",
  "zenoh-buffers",
  "zenoh-codec",
  "zenoh-collections",
  "zenoh-config",
  "zenoh-core",
- "zenoh-crypto",
  "zenoh-keyexpr",
  "zenoh-link",
  "zenoh-macros",
@@ -4803,20 +4697,19 @@ dependencies = [
 
 [[package]]
 name = "zenoh-buffers"
-version = "1.0.0-alpha.6"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dc32cbe83d9c605391e0b8f4d39fef491ae9c9e54062f1352bb2e05ebd6ca0b"
+checksum = "592504c9854fbc781b9a389cd7225b5878b8dd0cb9a12f15546c8d4eeba9a802"
 dependencies = [
  "zenoh-collections",
 ]
 
 [[package]]
 name = "zenoh-codec"
-version = "1.0.0-alpha.6"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11b0e8f93a429d052898ce8d1f9c521415b99e2acaf4e26a7eb593dd704e7d20"
+checksum = "bfb0ce6e9104408c6a23e100a69b16b8e5713f904e061b14ac994fef8df6baba"
 dependencies = [
- "serde",
  "tracing",
  "uhlc",
  "zenoh-buffers",
@@ -4825,17 +4718,16 @@ dependencies = [
 
 [[package]]
 name = "zenoh-collections"
-version = "1.0.0-alpha.6"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "374a6fc70c8f74bd025445fa035f9d556e286e3f60a000f0846a51a637f0acb4"
+checksum = "ccb27c67033ffda0171506658802fda8dc22e62bcb094b49be86c04f84d8bdab"
 
 [[package]]
 name = "zenoh-config"
-version = "1.0.0-alpha.6"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "124514ba9fb6748a5354badf0f128112274c93f845731493ec2334c4c3f7f8c5"
+checksum = "15d3ddf489ec055bc7498d66f6bb2cce8278314fbadb40aa34a37bc0125f494f"
 dependencies = [
- "flume",
  "json5",
  "num_cpus",
  "secrecy",
@@ -4854,11 +4746,10 @@ dependencies = [
 
 [[package]]
 name = "zenoh-core"
-version = "1.0.0-alpha.6"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f01b49ea5d5cb57306b8cc13bccf2dd7d7efce19ef51f4a972e1ff07ceb752b8"
+checksum = "0f3d36d0b828f429cfba005519de8941319a4ca3e0b21c7ede3cf8812e1e5518"
 dependencies = [
- "async-global-executor",
  "lazy_static",
  "tokio",
  "zenoh-result",
@@ -4867,9 +4758,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-crypto"
-version = "1.0.0-alpha.6"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eeda8889138fcc99ea0242bcbef4a6bfa10096fbf2fb0d87c41e331c2901904"
+checksum = "2f82ea1bb77132325e7fae5d698cfa5dddd4d6e46e94fc73409e31e65a557d7d"
 dependencies = [
  "aes",
  "hmac",
@@ -4881,9 +4772,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-keyexpr"
-version = "1.0.0-alpha.6"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "908e1217c0d205329f40dcfaa9a5e9768ac00e48efd4b259f3335139424726d3"
+checksum = "9adcce6a97d03855e2f2e7e5fafb9659d65c47eebc4dc6049ded397874ff634e"
 dependencies = [
  "hashbrown 0.14.5",
  "keyed-set",
@@ -4896,11 +4787,10 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link"
-version = "1.0.0-alpha.6"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "744c3378447b63c1d10f3a4308792e710a2794bf47484622494b0ad3b382909b"
+checksum = "73741cc9d89411d9b9e969cbad3a6e494684f3a79e200caebdad62beb3cb13fe"
 dependencies = [
- "async-trait",
  "zenoh-config",
  "zenoh-link-commons",
  "zenoh-link-quic",
@@ -4915,9 +4805,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link-commons"
-version = "1.0.0-alpha.6"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f3ff80909e7f61fa204f367bb6d7b91a4e69502fad228fa07dd98bfe5d3836"
+checksum = "6c74d63df6a0dda46f207699fafea4b832151b288451ce58eab7a56c8a07694d"
 dependencies = [
  "async-trait",
  "flume",
@@ -4928,10 +4818,8 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
- "webpki-roots",
  "zenoh-buffers",
  "zenoh-codec",
- "zenoh-config",
  "zenoh-core",
  "zenoh-protocol",
  "zenoh-result",
@@ -4941,13 +4829,12 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link-quic"
-version = "1.0.0-alpha.6"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac169d2de9d3b8bf3936206b3ebbe33d67236304ef26e4e4cd402d5cfb95d976"
+checksum = "9727ec46732859c14717fba67977ef94b866510e714db1270c2f56e19bd80dad"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
- "futures",
  "quinn",
  "rustls",
  "rustls-pemfile",
@@ -4955,27 +4842,22 @@ dependencies = [
  "rustls-webpki",
  "secrecy",
  "tokio",
- "tokio-rustls",
  "tokio-util",
  "tracing",
  "webpki-roots",
  "x509-parser",
- "zenoh-collections",
  "zenoh-config",
  "zenoh-core",
  "zenoh-link-commons",
  "zenoh-protocol",
  "zenoh-result",
- "zenoh-runtime",
- "zenoh-sync",
- "zenoh-util",
 ]
 
 [[package]]
 name = "zenoh-link-tcp"
-version = "1.0.0-alpha.6"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b1ab76691ef75b7e2cf8bdf2bb51d4c11e0021eb13cd92e73d4e64d620bf5c7"
+checksum = "394d7bd1a098ef102f58b13305f88ce1ffba007c6fe1df2c6d9c4bb350fcb5cb"
 dependencies = [
  "async-trait",
  "socket2 0.5.7",
@@ -4986,48 +4868,43 @@ dependencies = [
  "zenoh-link-commons",
  "zenoh-protocol",
  "zenoh-result",
- "zenoh-runtime",
- "zenoh-sync",
  "zenoh-util",
 ]
 
 [[package]]
 name = "zenoh-link-tls"
-version = "1.0.0-alpha.6"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13f8da6ca1bfa43a6d1e301142f9d3c513336dbdc94e58391cdb549bc495d356"
+checksum = "c9521f53cf61a41b654e976d33cfddb2e94dc0289ecba4cfa39bfb843824f767"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
- "futures",
  "rustls",
  "rustls-pemfile",
  "rustls-pki-types",
  "rustls-webpki",
  "secrecy",
  "socket2 0.5.7",
+ "tls-listener",
  "tokio",
  "tokio-rustls",
  "tokio-util",
  "tracing",
  "webpki-roots",
  "x509-parser",
- "zenoh-collections",
  "zenoh-config",
  "zenoh-core",
  "zenoh-link-commons",
  "zenoh-protocol",
  "zenoh-result",
  "zenoh-runtime",
- "zenoh-sync",
- "zenoh-util",
 ]
 
 [[package]]
 name = "zenoh-link-udp"
-version = "1.0.0-alpha.6"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81d93b2efa81a82409c6425aa15a9f539bfe6a5d37b6458b2414d646b3fd1d46"
+checksum = "3bd6e9814f1f0f7db6e02f8d196106e356e55e2d5814d1bc8f211910e6fb1459"
 dependencies = [
  "async-trait",
  "socket2 0.5.7",
@@ -5035,24 +4912,21 @@ dependencies = [
  "tokio-util",
  "tracing",
  "zenoh-buffers",
- "zenoh-collections",
  "zenoh-core",
  "zenoh-link-commons",
  "zenoh-protocol",
  "zenoh-result",
- "zenoh-runtime",
  "zenoh-sync",
  "zenoh-util",
 ]
 
 [[package]]
 name = "zenoh-link-unixsock_stream"
-version = "1.0.0-alpha.6"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5c22576c0dd0494552faa19e6c4ef48c09e064e49f35ae84c2d5175c14630a7"
+checksum = "aef73ad8357bf0c42abdb057686200bfd6c3fb4646ed07c13f6c18b363f1a0b6"
 dependencies = [
  "async-trait",
- "futures",
  "nix",
  "tokio",
  "tokio-util",
@@ -5063,14 +4937,13 @@ dependencies = [
  "zenoh-protocol",
  "zenoh-result",
  "zenoh-runtime",
- "zenoh-sync",
 ]
 
 [[package]]
 name = "zenoh-link-ws"
-version = "1.0.0-alpha.6"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44bd970d1f882741582b0fb91fc7f75fd7efe553d54176d321f218abf49c538a"
+checksum = "4f178df5cff946bc8ef81015df8d3106d19b027e9aff11db8aa2eee1a802cc05"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -5084,32 +4957,32 @@ dependencies = [
  "zenoh-protocol",
  "zenoh-result",
  "zenoh-runtime",
- "zenoh-sync",
  "zenoh-util",
 ]
 
 [[package]]
 name = "zenoh-macros"
-version = "1.0.0-alpha.6"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711d22524466cfb675bc6369b990d08d32e717ee3a33982c5717b16967042244"
+checksum = "528dc367e8de7e84d35d37d21998cf9a45360b0f8bffb4f9e5135bed45fd347f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.86",
  "zenoh-keyexpr",
 ]
 
 [[package]]
 name = "zenoh-plugin-trait"
-version = "1.0.0-alpha.6"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d77d6f534d2496eb7fe3c08951dedb52e374523df7564de2e7fe47a8a4b605d2"
+checksum = "a24cfd2508d900adad7c88617541b8d4a2ad581c15c307db798b6362554642fe"
 dependencies = [
+ "git-version",
  "libloading",
  "serde",
- "serde_json",
  "tracing",
+ "zenoh-config",
  "zenoh-keyexpr",
  "zenoh-macros",
  "zenoh-result",
@@ -5118,38 +4991,35 @@ dependencies = [
 
 [[package]]
 name = "zenoh-protocol"
-version = "1.0.0-alpha.6"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e312bcb7f9db84906a54c3bb12ed48d5a08166151f72003909c2856c18df9b04"
+checksum = "c342042f4e7ed51718803f48ce49d9dc2e1a8060f1ed7f94c21e781c01dac9d9"
 dependencies = [
  "const_format",
  "rand",
  "serde",
  "uhlc",
  "zenoh-buffers",
- "zenoh-collections",
  "zenoh-keyexpr",
  "zenoh-result",
 ]
 
 [[package]]
 name = "zenoh-result"
-version = "1.0.0-alpha.6"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acc55cac3fe4655a8687d81b918a2dfe459fd254ea5f387d5374f53911cc80b9"
+checksum = "05f79737b88aafb33bbb0ea83821c9048e20702f3de7cce8822adac25f100aa7"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "zenoh-runtime"
-version = "1.0.0-alpha.6"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e49e1aeff100cbbee624a68a85ec7affaa4d63960a36ef2605ce4b6641005e7"
+checksum = "30608ef77db6ba23df63901e3359299875474ff812c3d678b0101c88892cd3de"
 dependencies = [
- "futures",
  "lazy_static",
- "libc",
  "ron",
  "serde",
  "tokio",
@@ -5159,9 +5029,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-sync"
-version = "1.0.0-alpha.6"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bccefad1e7c30f8f4ccb7d0b46d1d99f2cc882bb09bdd050438178d4d94d910"
+checksum = "ef62536159fcfb7eb51d22b69894d884abea5ce0bf6241cc2c3f9880f486060b"
 dependencies = [
  "event-listener 5.3.1",
  "futures",
@@ -5169,14 +5039,13 @@ dependencies = [
  "zenoh-buffers",
  "zenoh-collections",
  "zenoh-core",
- "zenoh-runtime",
 ]
 
 [[package]]
 name = "zenoh-task"
-version = "1.0.0-alpha.6"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01279e8e5fa731049e2acf5bb7eeeaa7450a3362e5b0b5f31f24cc3f1318f039"
+checksum = "06d0efd5f0f70acc408a9bddeac526f91c85e2e42dc2c0d7c29a72bc9e26d6ca"
 dependencies = [
  "futures",
  "tokio",
@@ -5188,12 +5057,14 @@ dependencies = [
 
 [[package]]
 name = "zenoh-transport"
-version = "1.0.0-alpha.6"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9081d715d3fb1e153725627a115c5afc5cf40af45970c6677959c7a6a833f906"
+checksum = "3bc2a24c34c01775bd0601043dcd75de245eb3af35ce8eff96e0d9126e019812"
 dependencies = [
  "async-trait",
+ "crossbeam-utils",
  "flume",
+ "lazy_static",
  "lz4_flex",
  "paste",
  "rand",
@@ -5206,7 +5077,6 @@ dependencies = [
  "tracing",
  "zenoh-buffers",
  "zenoh-codec",
- "zenoh-collections",
  "zenoh-config",
  "zenoh-core",
  "zenoh-crypto",
@@ -5221,9 +5091,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-util"
-version = "1.0.0-alpha.6"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d53e24e5f203b37af4536e7e23733d9c3b1f2c5aaa8fce75dbc289c5f3909e"
+checksum = "afe24db564df9094e521441b556bfc73f359ae5d7b537a0b03257387404f561d"
 dependencies = [
  "async-trait",
  "const_format",
@@ -5247,9 +5117,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh_backend_traits"
-version = "1.0.0-alpha.6"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af71545acaac33b83164547c30b103218cf4a6a0ab13795e4668f7e7336d84ba"
+checksum = "812669d74a7200281a6b16e99e1f8b1fa166530982a506cc61dfba523a734b32"
 dependencies = [
  "async-trait",
  "const_format",
@@ -5281,7 +5151,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.86",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,14 +33,23 @@ async-trait = { version = "0.1" }
 clap = { version = "4.5" }
 env_logger = { version = "0.10.1" }
 futures = { version = "0.3.30" }
+lazy_static = { version = "1.5.0" }
 log = { version = "0.4.20" }
 json5 = { version =  "0.4.1" }
 serde = { version = "1.0.154", features = ["derive"] }
 serde_json = { version = "1.0.94" }
 uuid = { version = "1.7.0" }
-tokio = { version = "1.35.1", default-features = false }
+tokio = { version = "1.35.1", default-features = false, features = ["rt", "rt-multi-thread", "sync", "time"] }
 protobuf = { version = "3.3", features = ["with-bytes"] }
-up-rust = { version = "0.1.5", default-features = false }
+up-rust = { version = "0.2.0", default-features = false }
+up-transport-zenoh = { version = "0.3.0" }
+up-transport-vsomeip = { git = "https://github.com/eclipse-uprotocol/up-transport-vsomeip-rust.git", tag = "v0.3.0", default-features = false }
+zenoh = { version = "1.0.0", features = ["default", "plugins"] }
+zenoh-core = { version = "1.0.0" }
+zenoh-plugin-trait = { version = "1.0.0" }
+zenoh-result = { version = "1.0.0" }
+zenoh-util = { version = "1.0.0" }
+zenoh_backend_traits = { version = "1.0.0" }
 
 [profile.dev]
 debug = true

--- a/README.md
+++ b/README.md
@@ -15,9 +15,34 @@ Reference its README.md for further details.
 
 ## Building
 
-Included is a dependency on [up-transport-vsomeip-rust](https://github.com/eclipse-uprotocol/up-transport-vsomeip-rust) in order to communicate via SOME/IP that imposes some additional build considerations.
+### Only `up-streamer`
 
-Please reference the documentation for [vsomeip-sys](https://github.com/eclipse-uprotocol/up-transport-vsomeip-rust/tree/main/vsomeip-sys) and note
+If you only want to compile the library itself, you can as normal:
+
+```
+cargo build
+```
+
+### Also build the reference Zenoh, vsomeip streamer implementations
+
+You'll need to use the feature flags `vsomeip-transport` and `zenoh-transport`. You then also have the option of including your own vsomeip or using one bundled in `up-transport-vsomeip`.
+
+For the bundled option, the following:
+
+```
+GENERIC_CPP_STDLIB_PATH=<see-below> ARCH_SPECIFIC_CPP_STDLIB_PATH=<see-below> cargo build --features vsomeip-transport,bundled-vsomeip,zenoh-transport
+```
+
+where for reference on my machine:
+
+```
+GENERIC_CPP_STDLIB_PATH=/usr/include/c++/13
+ARCH_SPECIFIC_CPP_STDLIB_PATH=/usr/include/x86_64-linux-gnu/c++/13
+```
+
+These environment varialbes are necessary because of a workaround done in `up-transport-vsomeip` due to not being able to figure out another way to compile vsomeip without them. (If you can figure out how to avoid this, I'm all ears!)
+
+Please reference the documentation for [vsomeip-sys](https://github.com/eclipse-uprotocol/up-transport-vsomeip-rust/tree/main/vsomeip-sys) for more details on:
 * the build requirements for vsomeip in the linked documentation in the COVESA repo
 * the environment variables which must be set
 

--- a/example-streamer-uses/Cargo.toml
+++ b/example-streamer-uses/Cargo.toml
@@ -21,27 +21,40 @@ license.workspace = true
 
 [[bin]]
 name = "me_client"
+required-features = ["vsomeip-transport"]
 
 [[bin]]
 name = "me_publisher"
+required-features = ["vsomeip-transport"]
 
 [[bin]]
 name = "me_service"
+required-features = ["vsomeip-transport"]
 
 [[bin]]
 name = "me_subscriber"
+required-features = ["vsomeip-transport"]
 
 [[bin]]
 name = "ue_client"
+required-features = ["zenoh-transport"]
 
 [[bin]]
 name = "ue_publisher"
+required-features = ["zenoh-transport"]
 
 [[bin]]
 name = "ue_service"
+required-features = ["zenoh-transport"]
 
 [[bin]]
 name = "ue_subscriber"
+required-features = ["zenoh-transport"]
+
+[features]
+zenoh-transport = ["up-transport-zenoh", "zenoh"]
+vsomeip-transport = ["up-transport-vsomeip"]
+bundled-vsomeip = ["up-transport-vsomeip/bundled"]
 
 [dependencies]
 async-trait = { workspace = true }
@@ -55,6 +68,6 @@ protobuf = { workspace = true }
 serde = { workspace = true }
 tokio = { workspace = true }
 up-rust = { workspace = true }
-up-transport-zenoh = { version = "0.1.1"  }
-up-transport-vsomeip = { git = "https://github.com/eclipse-uprotocol/up-transport-vsomeip-rust.git", tag = "v0.1.0", default-features = false }
-zenoh = { version = "1.0.0-alpha.6", features = ["unstable"]}
+up-transport-zenoh = { workspace = true, optional = true }
+up-transport-vsomeip = { workspace = true, optional = true }
+zenoh = { workspace = true, optional = true }

--- a/example-streamer-uses/src/bin/ue_client.rs
+++ b/example-streamer-uses/src/bin/ue_client.rs
@@ -89,9 +89,8 @@ async fn main() -> Result<(), UStatus> {
         // Add the IPv4 endpoint to the Zenoh configuration
         zenoh_config
             .listen
-            .set_endpoints(zenoh::config::ModeDependentValue::Unique(vec![
-                ipv4_endpoint,
-            ]))
+            .endpoints
+            .set(vec![ipv4_endpoint])
             .expect("Unable to set Zenoh Config");
     }
 

--- a/example-streamer-uses/src/bin/ue_publisher.rs
+++ b/example-streamer-uses/src/bin/ue_publisher.rs
@@ -64,9 +64,8 @@ async fn main() -> Result<(), UStatus> {
         // Add the IPv4 endpoint to the Zenoh configuration
         zenoh_config
             .listen
-            .set_endpoints(zenoh::config::ModeDependentValue::Unique(vec![
-                ipv4_endpoint,
-            ]))
+            .endpoints
+            .set(vec![ipv4_endpoint])
             .expect("Unable to set Zenoh Config");
     }
 

--- a/example-streamer-uses/src/bin/ue_service.rs
+++ b/example-streamer-uses/src/bin/ue_service.rs
@@ -104,9 +104,8 @@ async fn main() -> Result<(), UStatus> {
         // Add the IPv4 endpoint to the Zenoh configuration
         zenoh_config
             .listen
-            .set_endpoints(zenoh::config::ModeDependentValue::Unique(vec![
-                ipv4_endpoint,
-            ]))
+            .endpoints
+            .set(vec![ipv4_endpoint])
             .expect("Unable to set Zenoh Config");
     }
 

--- a/example-streamer-uses/src/bin/ue_subscriber.rs
+++ b/example-streamer-uses/src/bin/ue_subscriber.rs
@@ -90,9 +90,8 @@ async fn main() -> Result<(), UStatus> {
         // Add the IPv4 endpoint to the Zenoh configuration
         zenoh_config
             .listen
-            .set_endpoints(zenoh::config::ModeDependentValue::Unique(vec![
-                ipv4_endpoint,
-            ]))
+            .endpoints
+            .set(vec![ipv4_endpoint])
             .expect("Unable to set Zenoh Config");
     }
 

--- a/up-linux-streamer-plugin/Cargo.toml
+++ b/up-linux-streamer-plugin/Cargo.toml
@@ -20,23 +20,26 @@ keywords.workspace = true
 license.workspace = true
 
 [features]
-default = ["bundled-vsomeip", "dynamic_plugin", "zenoh/default", "zenoh/unstable", "zenoh/plugins"]
+default = ["dynamic_plugin"]
+zenoh-transport = ["up-transport-zenoh", "zenoh", "zenoh-core", "zenoh-plugin-trait",
+                          "zenoh-result", "zenoh-util", "zenoh_backend_traits"]
+vsomeip-transport = ["up-transport-vsomeip"]
 bundled-vsomeip = ["up-transport-vsomeip/bundled"]
 dynamic_plugin = []
 
 [lib]
-# When auto-detecting the "example" plugin, `zenohd` will look for a dynamic library named "zenoh_plugin_example"
+# When auto-detecting the "up_linux_streamer" plugin, `zenohd` will look for a dynamic library named "zenoh_plugin_up_linux_streamer"
 # `zenohd` will expect the file to be named according to OS conventions:
-#   - libzenoh_plugin_example.so on linux
-#   - libzenoh_plugin_example.dylib on macOS
-#   - zenoh_plugin_example.dll on Windows
+#   - libzenoh_plugin_up_linux_streamer.so on linux
+#   - libzenoh_plugin_up_linux_streamer.dylib on macOS
+#   - zenoh_plugin_up_linux_streamer.dll on Windows
 name = "zenoh_plugin_up_linux_streamer"
 # This crate type will make `cargo` output a dynamic library instead of a rust static library
 crate-type = ["cdylib"]
 
 [dependencies]
-async-std = { version = "=1.12.0", default-features = false }
 const_format = "0.2.30"
+env_logger = "0.10.2"
 futures = { version = "0.3.25" }
 git-version = { version = "0.3.5" }
 tracing = { version = "0.1" }
@@ -44,14 +47,13 @@ serde = { version = "1.0.154" }
 serde_json = { version = "1.0.94" }
 tokio = { version = "1.35.1", default-features = false }
 up-rust = { workspace = true }
-up-transport-zenoh = { version = "0.1.1"  }
-up-transport-vsomeip = { git = "https://github.com/eclipse-uprotocol/up-transport-vsomeip-rust.git", tag = "v0.1.0", default-features = false }
+up-transport-zenoh = { workspace = true, optional = true }
+up-transport-vsomeip = { workspace = true, optional = true }
 up-streamer = { path = "../up-streamer" }
 usubscription-static-file = {path = "../utils/usubscription-static-file"}
-zenoh = { version = "1.0.0-alpha.6", features = ["unstable", "internal", "plugins"]}
-zenoh-core = { version = "1.0.0-alpha.6" }
-zenoh-plugin-trait = { version = "1.0.0-alpha.6" }
-zenoh-result = { version = "1.0.0-alpha.6" }
-zenoh-util = { version = "1.0.0-alpha.6" }
-zenoh_backend_traits = { version = "1.0.0-alpha.6" }
-env_logger = "0.10.2"
+zenoh = { workspace = true, optional = true }
+zenoh-core = { workspace = true, optional = true }
+zenoh-plugin-trait = { workspace = true, optional = true }
+zenoh-result = { workspace = true, optional = true }
+zenoh-util = { workspace = true, optional = true }
+zenoh_backend_traits = { workspace = true, optional = true }

--- a/up-linux-streamer-plugin/README.md
+++ b/up-linux-streamer-plugin/README.md
@@ -1,5 +1,7 @@
 # up-linux-streamer-plugin
 
+_Note_: Currently not usable. Must be updated to use tokio instead of async-std.
+
 ## The Concept
 
 ```mermaid

--- a/up-linux-streamer-plugin/src/lib.rs
+++ b/up-linux-streamer-plugin/src/lib.rs
@@ -18,229 +18,242 @@
 //  its members
 mod config;
 
-use crate::config::HostTransport;
-use async_std::task;
-use config::Config;
-use std::env;
-use std::str::FromStr;
-use std::sync::{
-    atomic::{AtomicBool, Ordering::Relaxed},
-    Arc, Mutex,
-};
-use std::time::Duration;
-use tracing::trace;
-use up_rust::{UTransport, UUri};
-use up_streamer::{Endpoint, UStreamer};
-use up_transport_vsomeip::UPTransportVsomeip;
-use up_transport_zenoh::UPTransportZenoh;
-use usubscription_static_file::USubscriptionStaticFile;
-use zenoh::internal::plugins::{RunningPluginTrait, ZenohPlugin};
-use zenoh::internal::runtime::Runtime;
-use zenoh_core::zlock;
-use zenoh_plugin_trait::{plugin_long_version, plugin_version, Plugin, PluginControl};
-use zenoh_result::{zerror, ZResult};
+#[cfg(all(feature = "zenoh-transport", feature = "vsomeip-transport"))]
+pub mod plugin {
 
-// The struct implementing the ZenohPlugin and ZenohPlugin traits
-pub struct UpLinuxStreamerPlugin {}
+    const THREAD_NUM: usize = 10;
 
-// declaration of the plugin's VTable for zenohd to find the plugin's functions to be called
-#[cfg(feature = "dynamic_plugin")]
-zenoh_plugin_trait::declare_plugin!(UpLinuxStreamerPlugin);
-
-impl ZenohPlugin for UpLinuxStreamerPlugin {}
-impl Plugin for UpLinuxStreamerPlugin {
-    type StartArgs = Runtime;
-    type Instance = zenoh::internal::plugins::RunningPlugin;
-
-    // A mandatory const to define, in case of the plugin is built as a standalone executable
-    const DEFAULT_NAME: &'static str = "up_linux_streamer";
-    const PLUGIN_VERSION: &'static str = plugin_version!();
-    const PLUGIN_LONG_VERSION: &'static str = plugin_long_version!();
-
-    // The first operation called by zenohd on the plugin
-    fn start(name: &str, runtime: &Self::StartArgs) -> ZResult<Self::Instance> {
-        zenoh_util::try_init_log_from_env();
-        trace!("up-linux-streamer-plugin: start");
-
-        let runtime_conf = runtime.config().lock();
-        let plugin_conf = runtime_conf
-            .plugin(name)
-            .ok_or_else(|| zerror!("Plugin `{}`: missing config", name))?;
-        let config: Config = serde_json::from_value(plugin_conf.clone())
-            .map_err(|e| zerror!("Plugin `{}` configuration error: {}", name, e))?;
-        trace!("loaded config: {config:?}");
-        trace!("succeeded in reading plugin config");
-
-        // a flag to end the plugin's loop when the plugin is removed from the config
-        let flag = Arc::new(AtomicBool::new(true));
-        // spawn the task running the plugin's loop
-        trace!("up-linux-streamer-plugin: before spawning run");
-        async_std::task::spawn(run(runtime.clone(), config.clone(), flag.clone()));
-        trace!("up-linux-streamer-plugin: after spawning run");
-        // return a RunningPlugin to zenohd
-        trace!("up-linux-streamer-plugin: before creating RunningPlugin");
-        let ret = Box::new(RunningPlugin(Arc::new(Mutex::new(RunningPluginInner {
-            flag,
-            name: name.into(),
-            runtime: runtime.clone(),
-        }))));
-        trace!("up-linux-streamer-plugin: after creating RunningPlugin");
-
-        Ok(ret)
-    }
-}
-
-// An inner-state for the RunningPlugin
-struct RunningPluginInner {
-    flag: Arc<AtomicBool>,
-    #[allow(dead_code)] // Allowing this to be able to configure streamer at runtime later
-    name: String,
-    #[allow(dead_code)] // Allowing this to be able to configure streamer at runtime later
-    runtime: Runtime,
-}
-// The RunningPlugin struct implementing the RunningPluginTrait trait
-#[derive(Clone)]
-struct RunningPlugin(Arc<Mutex<RunningPluginInner>>);
-
-impl PluginControl for RunningPlugin {}
-
-impl RunningPluginTrait for RunningPlugin {
-    fn config_checker(
-        &self,
-        _path: &str,
-        _old: &serde_json::Map<String, serde_json::Value>,
-        _new: &serde_json::Map<String, serde_json::Value>,
-    ) -> ZResult<Option<serde_json::Map<String, serde_json::Value>>> {
-        // TODO: Learn more about how the config_checker is used
-        Ok(None)
-    }
-}
-
-// If the plugin is dropped, set the flag to false to end the loop
-impl Drop for RunningPlugin {
-    fn drop(&mut self) {
-        zlock!(self.0).flag.store(false, Relaxed);
-    }
-}
-
-async fn run(runtime: Runtime, config: Config, flag: Arc<AtomicBool>) {
-    trace!("up-linux-streamer-plugin: inside of run");
-    zenoh_util::try_init_log_from_env();
-    trace!("up-linux-streamer-plugin: after try_init_log_from_env()");
-
-    trace!("attempt to call something on the runtime");
-    let timestamp_res = runtime.new_timestamp();
-    trace!("called function on runtime: {timestamp_res:?}");
-
-    env_logger::init();
-
-    let subscription_path = config.usubscription_config.file_path;
-    let usubscription = Arc::new(USubscriptionStaticFile::new(subscription_path));
-
-    let mut streamer = match UStreamer::new(
-        "up-linux-streamer",
-        config.up_streamer_config.message_queue_size,
-        usubscription,
-    ) {
-        Ok(streamer) => streamer,
-        Err(error) => panic!("Failed to create uStreamer: {}", error),
+    use crate::config::Config;
+    use crate::config::HostTransport;
+    use std::env;
+    use std::str::FromStr;
+    use std::sync::{
+        atomic::{AtomicBool, Ordering::Relaxed},
+        Arc, Mutex,
     };
+    use std::time::Duration;
+    use tracing::trace;
+    use up_rust::{UTransport, UUri};
+    use up_streamer::{Endpoint, UStreamer};
+    use up_transport_vsomeip::UPTransportVsomeip;
+    use up_transport_zenoh::UPTransportZenoh;
+    use usubscription_static_file::USubscriptionStaticFile;
+    use zenoh::internal::plugins::{RunningPluginTrait, ZenohPlugin};
+    use zenoh::internal::runtime::Runtime;
+    use zenoh_core::zlock;
+    use zenoh_plugin_trait::{plugin_long_version, plugin_version, Plugin, PluginControl};
+    use zenoh_result::{zerror, ZResult};
 
-    let streamer_uuri = UUri::try_from_parts(
-        &config.streamer_uuri.authority,
-        config.streamer_uuri.ue_id,
-        config.streamer_uuri.ue_version_major,
-        0,
-    )
-    .expect("Unable to form streamer_uuri");
+    // The struct implementing the ZenohPlugin and ZenohPlugin traits
+    pub struct UpLinuxStreamerPlugin {}
 
-    trace!("streamer_uuri: {streamer_uuri:#?}");
-    let streamer_uri: String = (&streamer_uuri).into();
-    // TODO: Remove this once the error reporting from UPTransportZenoh no longer "hides"
-    // the underlying reason for the failure on converting uri -> UUri
-    trace!("streamer_uri: {streamer_uri}");
-    let _zenoh_internal_uuri = UUri::from_str(&streamer_uri).map_err(|e| {
-        let msg = format!("Unable to transform the uri to UUri, e: {e:?}");
-        panic!("{msg}");
-    });
-    let host_transport: Arc<dyn UTransport> = Arc::new(match config.host_config.transport {
-        HostTransport::Zenoh => UPTransportZenoh::new_with_runtime(runtime.clone(), streamer_uri)
-            .await
-            .expect("Unable to initialize Zenoh UTransport"), // other host transports can be added here as they become available
-    });
+    // declaration of the plugin's VTable for zenohd to find the plugin's functions to be called
+    #[cfg(feature = "dynamic_plugin")]
+    zenoh_plugin_trait::declare_plugin!(UpLinuxStreamerPlugin);
 
-    let host_endpoint = Endpoint::new(
-        "host_endpoint",
-        &config.streamer_uuri.authority,
-        host_transport.clone(),
-    );
+    impl ZenohPlugin for UpLinuxStreamerPlugin {}
+    impl Plugin for UpLinuxStreamerPlugin {
+        type StartArgs = Runtime;
+        type Instance = zenoh::internal::plugins::RunningPlugin;
 
-    if config.someip_config.enabled {
-        let someip_config_file_abs_path = if config.someip_config.config_file.is_relative() {
-            env::current_dir()
-                .unwrap()
-                .join(&config.someip_config.config_file)
-        } else {
-            config.someip_config.config_file
-        };
-        tracing::log::trace!("someip_config_file_abs_path: {someip_config_file_abs_path:?}");
-        if !someip_config_file_abs_path.exists() {
-            panic!(
-                "The specified someip config_file doesn't exist: {someip_config_file_abs_path:?}"
-            );
+        // A mandatory const to define, in case of the plugin is built as a standalone executable
+        const DEFAULT_NAME: &'static str = "up_linux_streamer";
+        const PLUGIN_VERSION: &'static str = plugin_version!();
+        const PLUGIN_LONG_VERSION: &'static str = plugin_long_version!();
+
+        // The first operation called by zenohd on the plugin
+        fn start(name: &str, runtime: &Self::StartArgs) -> ZResult<Self::Instance> {
+            zenoh_util::try_init_log_from_env();
+            trace!("up-linux-streamer-plugin: start");
+
+            let runtime_conf = runtime.config().lock();
+            let plugin_conf = runtime_conf
+                .plugin(name)
+                .ok_or_else(|| zerror!("Plugin `{}`: missing config", name))?;
+            let config: Config = serde_json::from_value(plugin_conf.clone())
+                .map_err(|e| zerror!("Plugin `{}` configuration error: {}", name, e))?;
+            trace!("loaded config: {config:?}");
+            trace!("succeeded in reading plugin config");
+
+            // a flag to end the plugin's loop when the plugin is removed from the config
+            let flag = Arc::new(AtomicBool::new(true));
+            // spawn the task running the plugin's loop
+            trace!("up-linux-streamer-plugin: before spawning run");
+
+            let tokio_runtime = tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(THREAD_NUM)
+                .enable_all()
+                .build()
+                .expect("Unable to create runtime");
+            tokio_runtime.spawn(run(runtime.clone(), config.clone(), flag.clone()));
+            trace!("up-linux-streamer-plugin: after spawning run");
+            // return a RunningPlugin to zenohd
+            trace!("up-linux-streamer-plugin: before creating RunningPlugin");
+            let ret = Box::new(RunningPlugin(Arc::new(Mutex::new(RunningPluginInner {
+                flag,
+                name: name.into(),
+                runtime: runtime.clone(),
+            }))));
+            trace!("up-linux-streamer-plugin: after creating RunningPlugin");
+
+            Ok(ret)
         }
+    }
 
-        let host_uuri = UUri::try_from_parts(
+    // An inner-state for the RunningPlugin
+    struct RunningPluginInner {
+        flag: Arc<AtomicBool>,
+        #[allow(dead_code)] // Allowing this to be able to configure streamer at runtime later
+        name: String,
+        #[allow(dead_code)] // Allowing this to be able to configure streamer at runtime later
+        runtime: Runtime,
+    }
+    // The RunningPlugin struct implementing the RunningPluginTrait trait
+    #[derive(Clone)]
+    struct RunningPlugin(Arc<Mutex<RunningPluginInner>>);
+
+    impl PluginControl for RunningPlugin {}
+
+    impl RunningPluginTrait for RunningPlugin {
+        fn config_checker(
+            &self,
+            _path: &str,
+            _old: &serde_json::Map<String, serde_json::Value>,
+            _new: &serde_json::Map<String, serde_json::Value>,
+        ) -> ZResult<Option<serde_json::Map<String, serde_json::Value>>> {
+            // TODO: Learn more about how the config_checker is used
+            Ok(None)
+        }
+    }
+
+    // If the plugin is dropped, set the flag to false to end the loop
+    impl Drop for RunningPlugin {
+        fn drop(&mut self) {
+            zlock!(self.0).flag.store(false, Relaxed);
+        }
+    }
+
+    async fn run(runtime: Runtime, config: Config, flag: Arc<AtomicBool>) {
+        trace!("up-linux-streamer-plugin: inside of run");
+        zenoh_util::try_init_log_from_env();
+        trace!("up-linux-streamer-plugin: after try_init_log_from_env()");
+
+        trace!("attempt to call something on the runtime");
+        let timestamp_res = runtime.new_timestamp();
+        trace!("called function on runtime: {timestamp_res:?}");
+
+        env_logger::init();
+
+        let subscription_path = config.usubscription_config.file_path;
+        let usubscription = Arc::new(USubscriptionStaticFile::new(subscription_path));
+
+        let mut streamer = match UStreamer::new(
+            "up-linux-streamer",
+            config.up_streamer_config.message_queue_size,
+            usubscription,
+        ) {
+            Ok(streamer) => streamer,
+            Err(error) => panic!("Failed to create uStreamer: {}", error),
+        };
+
+        let streamer_uuri = UUri::try_from_parts(
             &config.streamer_uuri.authority,
-            config
-                .someip_config
-                .default_someip_application_id_for_someip_subscriptions as u32,
-            1,
+            config.streamer_uuri.ue_id,
+            config.streamer_uuri.ue_version_major,
             0,
         )
-        .expect("Unable to make host_uuri");
+        .expect("Unable to form streamer_uuri");
 
-        // There will be at most one vsomeip_transport, as there is a connection into device and a streamer
-        let someip_transport: Arc<dyn UTransport> = Arc::new(
-            UPTransportVsomeip::new_with_config(
-                host_uuri,
-                &config.someip_config.authority,
-                &someip_config_file_abs_path,
-                None,
+        trace!("streamer_uuri: {streamer_uuri:#?}");
+        let streamer_uri: String = (&streamer_uuri).into();
+        // TODO: Remove this once the error reporting from UPTransportZenoh no longer "hides"
+        // the underlying reason for the failure on converting uri -> UUri
+        trace!("streamer_uri: {streamer_uri}");
+        let _zenoh_internal_uuri = UUri::from_str(&streamer_uri).map_err(|e| {
+            let msg = format!("Unable to transform the uri to UUri, e: {e:?}");
+            panic!("{msg}");
+        });
+        let host_transport: Arc<dyn UTransport> = Arc::new(match config.host_config.transport {
+            HostTransport::Zenoh => {
+                UPTransportZenoh::new_with_runtime(runtime.clone(), streamer_uri)
+                    .await
+                    .expect("Unable to initialize Zenoh UTransport")
+            } // other host transports can be added here as they become available
+        });
+
+        let host_endpoint = Endpoint::new(
+            "host_endpoint",
+            &config.streamer_uuri.authority,
+            host_transport.clone(),
+        );
+
+        if config.someip_config.enabled {
+            let someip_config_file_abs_path = if config.someip_config.config_file.is_relative() {
+                env::current_dir()
+                    .unwrap()
+                    .join(&config.someip_config.config_file)
+            } else {
+                config.someip_config.config_file
+            };
+            tracing::log::trace!("someip_config_file_abs_path: {someip_config_file_abs_path:?}");
+            if !someip_config_file_abs_path.exists() {
+                panic!(
+                "The specified someip config_file doesn't exist: {someip_config_file_abs_path:?}"
+            );
+            }
+
+            let host_uuri = UUri::try_from_parts(
+                &config.streamer_uuri.authority,
+                config
+                    .someip_config
+                    .default_someip_application_id_for_someip_subscriptions as u32,
+                1,
+                0,
             )
-            .expect("Unable to initialize vsomeip UTransport"),
-        );
+            .expect("Unable to make host_uuri");
 
-        let mechatronics_endpoint = Endpoint::new(
-            "mechatronics_endpoint",
-            &config.someip_config.authority,
-            someip_transport.clone(),
-        );
-        let forwarding_res = streamer
-            .add_forwarding_rule(mechatronics_endpoint.clone(), host_endpoint.clone())
-            .await;
+            // There will be at most one vsomeip_transport, as there is a connection into device and a streamer
+            let someip_transport: Arc<dyn UTransport> = Arc::new(
+                UPTransportVsomeip::new_with_config(
+                    host_uuri,
+                    &config.someip_config.authority,
+                    &someip_config_file_abs_path,
+                    None,
+                )
+                .expect("Unable to initialize vsomeip UTransport"),
+            );
 
-        if let Err(err) = forwarding_res {
-            panic!("Unable to add forwarding result: {err:?}");
+            let mechatronics_endpoint = Endpoint::new(
+                "mechatronics_endpoint",
+                &config.someip_config.authority,
+                someip_transport.clone(),
+            );
+            let forwarding_res = streamer
+                .add_forwarding_rule(mechatronics_endpoint.clone(), host_endpoint.clone())
+                .await;
+
+            if let Err(err) = forwarding_res {
+                panic!("Unable to add forwarding result: {err:?}");
+            }
+
+            let forwarding_res = streamer
+                .add_forwarding_rule(host_endpoint.clone(), mechatronics_endpoint.clone())
+                .await;
+
+            if let Err(err) = forwarding_res {
+                panic!("Unable to add forwarding result: {err:?}");
+            }
         }
 
-        let forwarding_res = streamer
-            .add_forwarding_rule(host_endpoint.clone(), mechatronics_endpoint.clone())
-            .await;
+        // Plugin's event loop, while the flag is true
+        let mut counter = 1;
+        while flag.load(Relaxed) {
+            // TODO: Need to implement signaling to stop uStreamer
 
-        if let Err(err) = forwarding_res {
-            panic!("Unable to add forwarding result: {err:?}");
+            tokio::time::sleep(Duration::from_millis(1000)).await;
+            trace!("counter: {counter}");
+
+            counter += 1;
         }
-    }
-
-    // Plugin's event loop, while the flag is true
-    let mut counter = 1;
-    while flag.load(Relaxed) {
-        // TODO: Need to implement signaling to stop uStreamer
-
-        task::sleep(Duration::from_millis(1000)).await;
-        trace!("counter: {counter}");
-
-        counter += 1;
     }
 }

--- a/up-linux-streamer/Cargo.toml
+++ b/up-linux-streamer/Cargo.toml
@@ -19,8 +19,15 @@ edition.workspace = true
 keywords.workspace = true
 license.workspace = true
 
+[[bin]]
+name = "up-linux-streamer"
+path = "src/main.rs"
+required-features = ["zenoh-transport", "vsomeip-transport"]
+
 [features]
-default = ["bundled-vsomeip"]
+default = []
+zenoh-transport = ["up-transport-zenoh", "zenoh"]
+vsomeip-transport = ["up-transport-vsomeip"]
 bundled-vsomeip = ["up-transport-vsomeip/bundled"]
 
 [dependencies]
@@ -35,9 +42,9 @@ serde = { workspace = true }
 tokio = { workspace = true }
 up-rust = { workspace = true }
 up-streamer = { path = "../up-streamer" }
-up-transport-zenoh = { version = "0.1.1"  }
-up-transport-vsomeip = { git = "https://github.com/eclipse-uprotocol/up-transport-vsomeip-rust.git", tag = "v0.1.0", default-features = false }
-zenoh = { version = "1.0.0-alpha.6", features = ["unstable"]}
+up-transport-zenoh = { workspace = true, optional = true }
+up-transport-vsomeip = { workspace = true, optional = true }
+zenoh = { workspace = true, optional = true }
 usubscription-static-file = {path = "../utils/usubscription-static-file"}
 
 [dev-dependencies]

--- a/up-linux-streamer/src/main.rs
+++ b/up-linux-streamer/src/main.rs
@@ -35,7 +35,7 @@ struct StreamerArgs {
     config: String,
 }
 
-#[tokio::main]
+#[tokio::main(flavor = "multi_thread")]
 async fn main() -> Result<(), UStatus> {
     env_logger::init();
 

--- a/up-linux-streamer/vsomeip-configs/point_to_point.json
+++ b/up-linux-streamer/vsomeip-configs/point_to_point.json
@@ -5,5 +5,12 @@
       "name" : "foo",
       "id" : "0x1236"
     }
+  ],
+  "services" :
+  [
+    {
+      "service" : "0x1236",
+      "instance" : "0x0001"
+    }
   ]
 }

--- a/up-streamer/Cargo.toml
+++ b/up-streamer/Cargo.toml
@@ -22,10 +22,11 @@ license.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-std = { workspace = true, features = ["unstable"] }
+tokio = { workspace = true }
 async-trait = { workspace = true }
 env_logger = { workspace = true }
 futures = { workspace = true }
+lazy_static = { workspace = true }
 log = { workspace = true }
 uuid = { workspace = true }
 serde_json = { workspace = true }
@@ -38,3 +39,4 @@ usubscription-static-file = {path="../utils/usubscription-static-file"}
 async-broadcast = { version = "0.7.0" }
 chrono = { version = "0.4.31", features = [] }
 integration-test-utils = { path = "../utils/integration-test-utils" }
+tokio-condvar = { version = "0.3.0" }

--- a/up-streamer/src/endpoint.rs
+++ b/up-streamer/src/endpoint.rs
@@ -11,8 +11,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-use async_std::sync::Arc;
 use log::*;
+use std::sync::Arc;
 use up_rust::UTransport;
 
 const ENDPOINT_TAG: &str = "Endpoint:";
@@ -26,7 +26,7 @@ const ENDPOINT_FN_NEW_TAG: &str = "new():";
 ///
 /// ```
 /// use std::sync::Arc;
-/// use async_std::sync::Mutex;
+/// use tokio::sync::Mutex;
 /// use up_rust::UTransport;
 /// use up_streamer::Endpoint;
 ///

--- a/up-streamer/tests/single_local_single_remote.rs
+++ b/up-streamer/tests/single_local_single_remote.rs
@@ -12,8 +12,6 @@
  ********************************************************************************/
 
 use async_broadcast::broadcast;
-use async_std::sync::{Condvar, Mutex};
-use async_std::task;
 use futures::future::join;
 use integration_test_utils::{
     check_messages_in_order, check_send_receive_message_discrepancy, local_authority,
@@ -29,6 +27,8 @@ use log::debug;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
+use tokio::sync::Mutex;
+use tokio_condvar::Condvar;
 use up_rust::{UListener, UTransport};
 use up_streamer::{Endpoint, UStreamer};
 use usubscription_static_file::USubscriptionStaticFile;
@@ -36,7 +36,7 @@ use usubscription_static_file::USubscriptionStaticFile;
 const DURATION_TO_RUN_CLIENTS: u128 = 1_000;
 const SENT_MESSAGE_VEC_CAPACITY: usize = 10_000;
 
-#[async_std::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn single_local_single_remote() {
     // using async_broadcast to simulate communication protocol
     let (tx_1, rx_1) = broadcast(10000);
@@ -175,7 +175,7 @@ async fn single_local_single_remote() {
 
     debug!("after signal_to_resume");
 
-    task::sleep(Duration::from_millis(DURATION_TO_RUN_CLIENTS as u64)).await;
+    tokio::time::sleep(Duration::from_millis(DURATION_TO_RUN_CLIENTS as u64)).await;
 
     debug!("past wait on clients to run, now tell them to stop");
     {

--- a/up-streamer/tests/single_local_two_remote_add_remove_rules.rs
+++ b/up-streamer/tests/single_local_two_remote_add_remove_rules.rs
@@ -12,8 +12,6 @@
  ********************************************************************************/
 
 use async_broadcast::broadcast;
-use async_std::sync::{Condvar, Mutex};
-use async_std::task;
 use futures::future::join;
 use integration_test_utils::{
     check_messages_in_order, check_send_receive_message_discrepancy, local_authority,
@@ -30,6 +28,8 @@ use log::debug;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
+use tokio::sync::Mutex;
+use tokio_condvar::Condvar;
 use up_rust::{UListener, UTransport};
 use up_streamer::{Endpoint, UStreamer};
 use usubscription_static_file::USubscriptionStaticFile;
@@ -37,7 +37,7 @@ use usubscription_static_file::USubscriptionStaticFile;
 const DURATION_TO_RUN_CLIENTS: u128 = 500;
 const SENT_MESSAGE_VEC_CAPACITY: usize = 20_000;
 
-#[async_std::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn single_local_two_remote_add_remove_rules() {
     // using async_broadcast to simulate communication protocol
     let (tx_1, rx_1) = broadcast(20000);
@@ -206,7 +206,7 @@ async fn single_local_two_remote_add_remove_rules() {
 
     debug!("signalled to resume");
 
-    task::sleep(Duration::from_millis(DURATION_TO_RUN_CLIENTS as u64)).await;
+    tokio::time::sleep(Duration::from_millis(DURATION_TO_RUN_CLIENTS as u64)).await;
 
     {
         let mut local_command = local_command.lock().await;
@@ -289,7 +289,7 @@ async fn single_local_two_remote_add_remove_rules() {
 
     debug!("signalled local, remote_a, remote_b to resume");
 
-    task::sleep(Duration::from_millis(DURATION_TO_RUN_CLIENTS as u64)).await;
+    tokio::time::sleep(Duration::from_millis(DURATION_TO_RUN_CLIENTS as u64)).await;
 
     debug!("after running local, remote_a, remote_b");
 
@@ -345,7 +345,7 @@ async fn single_local_two_remote_add_remove_rules() {
 
     debug!("signalled all to resume: local & remote_b");
 
-    task::sleep(Duration::from_millis(DURATION_TO_RUN_CLIENTS as u64)).await;
+    tokio::time::sleep(Duration::from_millis(DURATION_TO_RUN_CLIENTS as u64)).await;
 
     {
         let mut local_command = local_command.lock().await;

--- a/up-streamer/tests/single_local_two_remote_authorities_different_remote_transport.rs
+++ b/up-streamer/tests/single_local_two_remote_authorities_different_remote_transport.rs
@@ -12,8 +12,6 @@
  ********************************************************************************/
 
 use async_broadcast::broadcast;
-use async_std::sync::{Condvar, Mutex};
-use async_std::task;
 use futures::future::join;
 use integration_test_utils::{
     check_messages_in_order, check_send_receive_message_discrepancy, local_authority,
@@ -30,6 +28,8 @@ use log::debug;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
+use tokio::sync::Mutex;
+use tokio_condvar::Condvar;
 use up_rust::{UListener, UTransport};
 use up_streamer::{Endpoint, UStreamer};
 use usubscription_static_file::USubscriptionStaticFile;
@@ -37,7 +37,7 @@ use usubscription_static_file::USubscriptionStaticFile;
 const DURATION_TO_RUN_CLIENTS: u128 = 1_000;
 const SENT_MESSAGE_VEC_CAPACITY: usize = 10_000;
 
-#[async_std::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn single_local_two_remote_authorities_different_remote_transport() {
     // using async_broadcast to simulate communication protocol
     let (tx_1, rx_1) = broadcast(20000);
@@ -253,7 +253,7 @@ async fn single_local_two_remote_authorities_different_remote_transport() {
     // Now signal both clients to resume
     signal_to_resume(all_signal_should_pause.clone()).await;
 
-    task::sleep(Duration::from_millis(DURATION_TO_RUN_CLIENTS as u64)).await;
+    tokio::time::sleep(Duration::from_millis(DURATION_TO_RUN_CLIENTS as u64)).await;
 
     {
         let mut local_command = local_command.lock().await;

--- a/up-streamer/tests/single_local_two_remote_authorities_same_remote_transport.rs
+++ b/up-streamer/tests/single_local_two_remote_authorities_same_remote_transport.rs
@@ -12,8 +12,6 @@
  ********************************************************************************/
 
 use async_broadcast::broadcast;
-use async_std::sync::{Condvar, Mutex};
-use async_std::task;
 use futures::future::join;
 use integration_test_utils::{
     check_messages_in_order, check_send_receive_message_discrepancy, local_authority,
@@ -30,6 +28,8 @@ use log::debug;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
+use tokio::sync::Mutex;
+use tokio_condvar::Condvar;
 use up_rust::{UListener, UTransport};
 use up_streamer::{Endpoint, UStreamer};
 use usubscription_static_file::USubscriptionStaticFile;
@@ -37,7 +37,7 @@ use usubscription_static_file::USubscriptionStaticFile;
 const DURATION_TO_RUN_CLIENTS: u128 = 1_000;
 const SENT_MESSAGE_VEC_CAPACITY: usize = 10_000;
 
-#[async_std::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn single_local_two_remote_authorities_same_remote_transport() {
     // using async_broadcast to simulate communication protocol
     let (tx_1, rx_1) = broadcast(20000);
@@ -257,7 +257,7 @@ async fn single_local_two_remote_authorities_same_remote_transport() {
     // Now signal both clients to resume
     signal_to_resume(all_signal_should_pause.clone()).await;
 
-    task::sleep(Duration::from_millis(DURATION_TO_RUN_CLIENTS as u64)).await;
+    tokio::time::sleep(Duration::from_millis(DURATION_TO_RUN_CLIENTS as u64)).await;
 
     {
         let mut local_command = local_command.lock().await;

--- a/up-streamer/tests/usubscription.rs
+++ b/up-streamer/tests/usubscription.rs
@@ -17,7 +17,7 @@ use up_rust::{UCode, UStatus, UTransport};
 use up_streamer::{Endpoint, UStreamer};
 use usubscription_static_file::USubscriptionStaticFile;
 
-#[async_std::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn usubscription_bad_data() {
     let utransport_foo: Arc<dyn UTransport> =
         Arc::new(UPClientFailingRegister::new("upclient_foo").await);

--- a/utils/integration-test-utils/Cargo.toml
+++ b/utils/integration-test-utils/Cargo.toml
@@ -23,7 +23,6 @@ license.workspace = true
 
 [dependencies]
 async-broadcast = { version = "0.7.0" }
-async-std = { workspace = true, features = ["unstable"] }
 async-trait = { workspace = true }
 env_logger = { workspace = true }
 futures = { workspace = true }
@@ -33,3 +32,5 @@ serde_json = { workspace = true }
 up-rust = { workspace = true }
 up-streamer = { path = "../../up-streamer" }
 rand = "0.8.5"
+tokio = { workspace = true }
+tokio-condvar = { version = "0.3.0" }

--- a/utils/integration-test-utils/src/integration_test_listeners.rs
+++ b/utils/integration-test-utils/src/integration_test_listeners.rs
@@ -11,10 +11,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-use async_std::sync::Mutex;
 use async_trait::async_trait;
 use log::debug;
 use std::sync::Arc;
+use tokio::sync::Mutex;
 use up_rust::{UListener, UMessage};
 
 #[derive(Clone)]


### PR DESCRIPTION
~_Note_: Opening as draft pull request as we need to have https://github.com/eclipse-uprotocol/up-transport-vsomeip-rust/pull/31 merge first.~

Above PR merged, so removed draft status.

### Testing Status of Examples

I did a manual test of the examples to make sure that communications were flowing.

|                               | ✅ or ❌ |
|-------------------------------|--------|
| me_client <-> ue_service      | ✅      |
| ue_client <-> me_service      | ✅      |
| me_publisher -> ue_subscriber | ✅      |
| ue_publisher -> me_subscriber | ✅      |