### PR TITLE
bench: criterion harness and guardrail crate (c4)

### DIFF
--- a/.github/workflows/benchmark-guardrail-advisory.yaml
+++ b/.github/workflows/benchmark-guardrail-advisory.yaml
@@ -1,0 +1,66 @@
+# ********************************************************************************
+#  Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************/
+
+name: Benchmark Guardrail Advisory
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/benchmark-guardrail-advisory.yaml"
+      - "up-streamer/**"
+      - "utils/criterion-guardrail/**"
+      - "scripts/bench_streamer_criterion.sh"
+  workflow_dispatch:
+
+jobs:
+  criterion_guardrail_advisory:
+    name: Criterion Guardrail Advisory
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Add execute permissions for scripts
+        run: chmod +x build/envsetup.sh scripts/bench_streamer_criterion.sh
+
+      - name: Benchmark baseline and candidate
+        shell: bash
+        run: |
+          source build/envsetup.sh highest
+          export CRITERION_ARGS="--sample-size 60 --warm-up-time 3 --measurement-time 12 --noise-threshold 0.02"
+          if command -v taskset >/dev/null; then export BENCH_PIN_PREFIX="taskset -c 2"; else export BENCH_PIN_PREFIX=""; fi
+          scripts/bench_streamer_criterion.sh baseline
+          scripts/bench_streamer_criterion.sh candidate ci_candidate
+
+      - name: Run criterion-guardrail (advisory)
+        continue-on-error: true
+        run: |
+          scripts/bench_streamer_criterion.sh guardrail ci_candidate "$GITHUB_WORKSPACE/target/criterion/ci-guardrail.json"
+
+      - name: Export bencher compare output (advisory)
+        continue-on-error: true
+        shell: bash
+        run: |
+          export OPENCODE_CONFIG_DIR="$GITHUB_WORKSPACE/target/criterion-artifacts"
+          scripts/bench_streamer_criterion.sh export
+
+      - name: Upload criterion guardrail artifacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: criterion-guardrail-advisory
+          if-no-files-found: warn
+          path: |
+            target/criterion/ci-guardrail.json
+            target/criterion-artifacts/reports/ergonomics-perf/bench-data/criterion-compare-bencher.txt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,6 +66,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -613,6 +619,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -661,6 +673,33 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -861,6 +900,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "csv",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-guardrail"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "clap",
+ "csv",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
 name = "crossbeam"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -917,6 +1006,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -924,6 +1019,27 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1553,6 +1669,17 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2598,6 +2725,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "openssl"
 version = "0.10.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2915,6 +3048,34 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "pnet_base"
@@ -4429,6 +4590,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4956,6 +5127,7 @@ dependencies = [
  "async-broadcast",
  "async-trait",
  "chrono",
+ "criterion",
  "futures",
  "integration-test-utils",
  "protobuf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "utils/hello-world-protos",
     "utils/integration-test-utils",
     "example-streamer-implementations",
+    "utils/criterion-guardrail",
     "configurable-streamer",
     "up-linux-streamer-plugin",
     "up-streamer",

--- a/scripts/bench_streamer_criterion.sh
+++ b/scripts/bench_streamer_criterion.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+readonly DEFAULT_CRITERION_ARGS="--sample-size 60 --warm-up-time 3 --measurement-time 12 --noise-threshold 0.02"
+
+CRITERION_ARGS="${CRITERION_ARGS:-$DEFAULT_CRITERION_ARGS}"
+BENCH_PIN_PREFIX="${BENCH_PIN_PREFIX:-}"
+
+run_bench() {
+    if [[ -n "$BENCH_PIN_PREFIX" ]]; then
+        read -r -a pin_parts <<<"$BENCH_PIN_PREFIX"
+        "${pin_parts[@]}" cargo bench -p up-streamer --bench streamer_criterion -- $CRITERION_ARGS "$@"
+    else
+        cargo bench -p up-streamer --bench streamer_criterion -- $CRITERION_ARGS "$@"
+    fi
+}
+
+usage() {
+    cat <<'USAGE'
+Usage:
+  scripts/bench_streamer_criterion.sh baseline
+  scripts/bench_streamer_criterion.sh candidate <phase_candidate>
+  scripts/bench_streamer_criterion.sh guardrail <phase_candidate> <report_path>
+  scripts/bench_streamer_criterion.sh export
+USAGE
+}
+
+if [[ $# -lt 1 ]]; then
+    usage
+    exit 1
+fi
+
+subcommand="$1"
+shift
+
+case "$subcommand" in
+baseline)
+    run_bench --save-baseline ergonomics_baseline
+    ;;
+candidate)
+    if [[ $# -ne 1 ]]; then
+        usage
+        exit 1
+    fi
+    run_bench --save-baseline "$1"
+    ;;
+guardrail)
+    if [[ $# -ne 2 ]]; then
+        usage
+        exit 1
+    fi
+    cargo run -p criterion-guardrail -- \
+      --criterion-root target/criterion \
+      --baseline ergonomics_baseline \
+      --candidate "$1" \
+      --throughput-threshold-pct 3 \
+      --latency-threshold-pct 5 \
+      --alloc-proxy-threshold-pct 5 \
+      --report "$2"
+    ;;
+export)
+    : "${OPENCODE_CONFIG_DIR:?OPENCODE_CONFIG_DIR must be set for export output path}"
+    report_path="$OPENCODE_CONFIG_DIR/reports/ergonomics-perf/bench-data/criterion-compare-bencher.txt"
+    mkdir -p "$(dirname "$report_path")"
+    run_bench --baseline ergonomics_baseline --output-format bencher | tee "$report_path"
+    ;;
+*)
+    usage
+    exit 1
+    ;;
+esac

--- a/up-streamer/Cargo.toml
+++ b/up-streamer/Cargo.toml
@@ -32,8 +32,13 @@ arc-swap = "1.7"
 [dev-dependencies]
 async-broadcast = { version = "0.7.0" }
 chrono = { version = "0.4.31", features = [] }
+criterion = { version = "0.5.1", features = ["csv_output"] }
 futures = { workspace = true }
 integration-test-utils = { path = "../utils/integration-test-utils" }
 tokio-condvar = { version = "0.3.0" }
 up-rust = { workspace = true, features = ["test-util"] }
 usubscription-static-file = { path = "../utils/usubscription-static-file" }
+
+[[bench]]
+name = "streamer_criterion"
+harness = false

--- a/up-streamer/README.md
+++ b/up-streamer/README.md
@@ -28,16 +28,16 @@ sequenceDiagram
   
     main thread->>main thread: let ustreamer = UStreamer::new()
 
-    main thread->>main thread: ustreamer.add_forwarding_rule(local_endpoint, remote_endpoint)
+    main thread->>main thread: ustreamer.add_route(local_endpoint, remote_endpoint)
     main thread->>TransportForwarder - Foo: launch TransportForwarder - Foo
     activate TransportForwarder - Foo
-    main thread->>UPClientFoo owned thread / task: (within ustreamer.add_forwarding_rule()) <br> local_endpoint.transport.lock().await.register_listener <br> (uauthority_to_uuri(remote_endpoint.authority), forwarding_listener).await
+    main thread->>UPClientFoo owned thread / task: (within ustreamer.add_route()) <br> local_endpoint.transport.lock().await.register_listener <br> (uauthority_to_uuri(remote_endpoint.authority), forwarding_listener).await
     activate UPClientFoo owned thread / task
 
-    main thread->>main thread: ustreamer.add_forwarding_rule(remote_endpoint, local_endpoint)
+    main thread->>main thread: ustreamer.add_route(remote_endpoint, local_endpoint)
     main thread->>TransportForwarder - Bar: launch TransportForwarder - Bar
     activate TransportForwarder - Bar
-    main thread->>UPClientBar owned thread / task: (within ustreamer.add_forwarding_rule()) <br> remote_endpoint.transport.lock().await.register_listener <br> (uauthority_to_uuri(local_endpoint.authority), forwarding_listener).await
+    main thread->>UPClientBar owned thread / task: (within ustreamer.add_route()) <br> remote_endpoint.transport.lock().await.register_listener <br> (uauthority_to_uuri(local_endpoint.authority), forwarding_listener).await
     activate UPClientBar owned thread / task
 
     loop Park the main thread, let background tasks run until closing UStreamer app
@@ -93,3 +93,34 @@ After following along with the [cargo docs](#generating-cargo-docs-locally) gene
 - [x] Routing of Request, Response, and Notification Messages
 - [ ] Routing of Publish messages (requires further development of uSubscription interface)
 - [x] Mechanism to retrieve messages received on and sent over transports
+
+## Benchmark Guardrails
+
+`up-streamer` uses a pinned Criterion harness (`criterion = 0.5.1`) at:
+
+- `up-streamer/benches/streamer_criterion.rs`
+
+The helper script runs canonical benchmark commands and can invoke the Rust guardrail CLI:
+
+```bash
+export CRITERION_ARGS="--sample-size 60 --warm-up-time 3 --measurement-time 12 --noise-threshold 0.02"
+if command -v taskset >/dev/null; then export BENCH_PIN_PREFIX="taskset -c 2"; else export BENCH_PIN_PREFIX=""; fi
+
+scripts/bench_streamer_criterion.sh baseline
+scripts/bench_streamer_criterion.sh candidate ergonomics_candidate_slice_a
+scripts/bench_streamer_criterion.sh guardrail ergonomics_candidate_slice_a "$OPENCODE_CONFIG_DIR/reports/ergonomics-perf/bench-data/criterion-guardrail.json"
+scripts/bench_streamer_criterion.sh export
+```
+
+Threshold pass/fail evaluation is handled only by the Rust CLI:
+
+```bash
+cargo run -p criterion-guardrail -- \
+  --criterion-root target/criterion \
+  --baseline ergonomics_baseline \
+  --candidate ergonomics_candidate_slice_a \
+  --throughput-threshold-pct 3 \
+  --latency-threshold-pct 5 \
+  --alloc-proxy-threshold-pct 5 \
+  --report "$OPENCODE_CONFIG_DIR/reports/ergonomics-perf/bench-data/criterion-guardrail.json"
+```

--- a/up-streamer/benches/streamer_criterion.rs
+++ b/up-streamer/benches/streamer_criterion.rs
@@ -1,0 +1,128 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
+use tokio::runtime::Builder;
+use up_streamer::benchmark_support::{
+    run_single_route_dispatch_once, IngressRegistryFixture, PublishResolutionFixture,
+    RoutingLookupFixture,
+};
+
+const ROUTING_LOOKUP_ROWS: usize = 256;
+const PUBLISH_RESOLUTION_ROWS: usize = 512;
+const INGRESS_REGISTRY_ROWS: usize = 128;
+const INGRESS_BATCH_OPS: usize = 8;
+
+fn streamer_criterion(c: &mut Criterion) {
+    let runtime = Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("benchmark runtime should build");
+
+    let exact_lookup_fixture = runtime
+        .block_on(RoutingLookupFixture::exact_authority(ROUTING_LOOKUP_ROWS))
+        .expect("exact-authority lookup fixture should build");
+    let wildcard_lookup_fixture = runtime
+        .block_on(RoutingLookupFixture::wildcard_authority(
+            ROUTING_LOOKUP_ROWS,
+        ))
+        .expect("wildcard-authority lookup fixture should build");
+
+    let mut routing_lookup_group = c.benchmark_group("routing_lookup");
+    routing_lookup_group.bench_function("exact_authority", |b| {
+        b.iter(|| {
+            let count = runtime.block_on(exact_lookup_fixture.lookup_count());
+            black_box(count);
+        });
+    });
+    routing_lookup_group.bench_function("wildcard_authority", |b| {
+        b.iter(|| {
+            let count = runtime.block_on(wildcard_lookup_fixture.lookup_count());
+            black_box(count);
+        });
+    });
+    routing_lookup_group.finish();
+
+    let publish_resolution_fixture = runtime
+        .block_on(PublishResolutionFixture::new(PUBLISH_RESOLUTION_ROWS))
+        .expect("publish-resolution fixture should build");
+
+    let mut publish_resolution_group = c.benchmark_group("publish_resolution");
+    publish_resolution_group.bench_function("source_filter_derivation", |b| {
+        b.iter(|| {
+            let count = publish_resolution_fixture.derive_source_filter_count();
+            black_box(count);
+        });
+    });
+    publish_resolution_group.finish();
+
+    let mut ingress_registry_group = c.benchmark_group("ingress_registry");
+    ingress_registry_group.bench_function("register_route", |b| {
+        b.iter_batched(
+            || {
+                runtime
+                    .block_on(IngressRegistryFixture::new(INGRESS_REGISTRY_ROWS))
+                    .expect("ingress-registry fixture should build")
+            },
+            |fixture| {
+                for _ in 0..INGRESS_BATCH_OPS {
+                    let registered = runtime.block_on(fixture.register_route());
+                    assert!(
+                        registered,
+                        "register benchmark iteration should register route"
+                    );
+                    runtime.block_on(fixture.unregister_route());
+                    black_box(registered);
+                }
+            },
+            BatchSize::SmallInput,
+        );
+    });
+    ingress_registry_group.bench_function("unregister_route", |b| {
+        b.iter_batched(
+            || {
+                let fixture = runtime
+                    .block_on(IngressRegistryFixture::new(INGRESS_REGISTRY_ROWS))
+                    .expect("ingress-registry fixture should build");
+                let primed = runtime.block_on(fixture.register_route());
+                assert!(primed, "unregister benchmark setup should prime route");
+                fixture
+            },
+            |fixture| {
+                for _ in 0..INGRESS_BATCH_OPS {
+                    runtime.block_on(fixture.unregister_route());
+                    let re_registered = runtime.block_on(fixture.register_route());
+                    assert!(
+                        re_registered,
+                        "unregister benchmark iteration should restore route"
+                    );
+                }
+                black_box(());
+            },
+            BatchSize::SmallInput,
+        );
+    });
+    ingress_registry_group.finish();
+
+    let mut egress_forwarding_group = c.benchmark_group("egress_forwarding");
+    egress_forwarding_group.bench_function("single_route_dispatch", |b| {
+        b.iter(|| {
+            let send_count = runtime.block_on(run_single_route_dispatch_once());
+            black_box(send_count);
+        });
+    });
+    egress_forwarding_group.finish();
+}
+
+criterion_group!(benches, streamer_criterion);
+criterion_main!(benches);

--- a/up-streamer/src/benchmark_support.rs
+++ b/up-streamer/src/benchmark_support.rs
@@ -1,0 +1,346 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+//! Deterministic benchmark fixtures for the Criterion harness.
+
+use crate::data_plane::egress_worker::EgressRouteWorker;
+use crate::data_plane::ingress_registry::IngressRouteRegistry;
+use crate::routing::publish_resolution::PublishRouteResolver;
+use crate::routing::subscription_directory::SubscriptionDirectory;
+use async_trait::async_trait;
+use std::str::FromStr;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use tokio::sync::broadcast;
+use up_rust::core::usubscription::{FetchSubscriptionsResponse, SubscriberInfo, Subscription};
+use up_rust::{UCode, UListener, UMessage, UStatus, UTransport, UUri};
+
+fn subscription(topic: UUri, subscriber: UUri) -> Subscription {
+    Subscription {
+        topic: Some(topic).into(),
+        subscriber: Some(SubscriberInfo {
+            uri: Some(subscriber).into(),
+            ..Default::default()
+        })
+        .into(),
+        ..Default::default()
+    }
+}
+
+fn topic_uri(authority: &str, index: usize) -> UUri {
+    let ue_id = 0x5BA0 + (index as u32 % 0x1F0);
+    let resource_id = 0x8001 + (index as u16 % 0x01F0);
+
+    if authority == "*" {
+        return UUri::from_str(&format!("//*/{ue_id:X}/1/{resource_id:X}"))
+            .expect("wildcard topic URI should parse");
+    }
+
+    UUri::try_from_parts(authority, ue_id, 0x1, resource_id).expect("topic URI should build")
+}
+
+fn subscriber_uri(authority: &str, index: usize) -> UUri {
+    let ue_id = 0x7000 + (index as u32 % 0x200);
+    let resource_id = 0x9000 + (index as u16 % 0x200);
+
+    if authority == "*" {
+        return UUri::from_str(&format!("//*/{ue_id:X}/1/{resource_id:X}"))
+            .expect("wildcard subscriber URI should parse");
+    }
+
+    UUri::try_from_parts(authority, ue_id, 0x1, resource_id).expect("subscriber URI should build")
+}
+
+async fn directory_from_subscriptions(
+    subscriptions: Vec<Subscription>,
+) -> Result<SubscriptionDirectory, UStatus> {
+    let directory = SubscriptionDirectory::empty();
+    directory
+        .apply_snapshot(FetchSubscriptionsResponse {
+            subscriptions,
+            ..Default::default()
+        })
+        .await?;
+    Ok(directory)
+}
+
+fn build_subscriptions(
+    topic_authority: &str,
+    subscriber_authority: &str,
+    rows: usize,
+) -> Vec<Subscription> {
+    let total_rows = rows.max(1);
+    let mut subscriptions = Vec::with_capacity(total_rows);
+
+    for index in 0..total_rows {
+        subscriptions.push(subscription(
+            topic_uri(topic_authority, index),
+            subscriber_uri(subscriber_authority, index),
+        ));
+    }
+
+    subscriptions
+}
+
+/// Fixed fixture for `routing_lookup/*` benchmark IDs.
+pub struct RoutingLookupFixture {
+    directory: SubscriptionDirectory,
+    out_authority: String,
+}
+
+impl RoutingLookupFixture {
+    pub async fn exact_authority(rows: usize) -> Result<Self, UStatus> {
+        let out_authority = "authority-b".to_string();
+        let subscriptions = build_subscriptions("authority-a", &out_authority, rows);
+        let directory = directory_from_subscriptions(subscriptions).await?;
+
+        Ok(Self {
+            directory,
+            out_authority,
+        })
+    }
+
+    pub async fn wildcard_authority(rows: usize) -> Result<Self, UStatus> {
+        let out_authority = "authority-b".to_string();
+        let subscriptions = build_subscriptions("authority-a", "*", rows);
+        let directory = directory_from_subscriptions(subscriptions).await?;
+
+        Ok(Self {
+            directory,
+            out_authority,
+        })
+    }
+
+    pub async fn lookup_count(&self) -> usize {
+        self.directory
+            .lookup_route_subscribers_with_version(&self.out_authority)
+            .await
+            .1
+            .len()
+    }
+}
+
+/// Fixed fixture for `publish_resolution/source_filter_derivation` benchmark ID.
+pub struct PublishResolutionFixture {
+    subscribers: crate::routing::subscription_cache::SubscriptionLookup,
+    ingress_authority: String,
+    egress_authority: String,
+}
+
+impl PublishResolutionFixture {
+    pub async fn new(rows: usize) -> Result<Self, UStatus> {
+        let ingress_authority = "authority-a".to_string();
+        let egress_authority = "authority-b".to_string();
+        let total_rows = rows.max(1);
+        let mut subscriptions = Vec::with_capacity(total_rows);
+
+        for index in 0..total_rows {
+            let topic_authority = if index % 3 == 0 {
+                "*"
+            } else {
+                ingress_authority.as_str()
+            };
+            let topic = topic_uri(topic_authority, index % 64);
+            let subscriber = subscriber_uri(&egress_authority, index);
+            subscriptions.push(subscription(topic, subscriber));
+        }
+
+        let directory = directory_from_subscriptions(subscriptions).await?;
+        let subscribers = directory
+            .lookup_route_subscribers_with_version(&egress_authority)
+            .await
+            .1;
+
+        Ok(Self {
+            subscribers,
+            ingress_authority,
+            egress_authority,
+        })
+    }
+
+    pub fn derive_source_filter_count(&self) -> usize {
+        PublishRouteResolver::derive_source_filters(
+            &self.ingress_authority,
+            &self.egress_authority,
+            &self.subscribers,
+        )
+        .len()
+    }
+}
+
+struct NoopRegistryTransport;
+
+#[async_trait]
+impl UTransport for NoopRegistryTransport {
+    async fn send(&self, _message: UMessage) -> Result<(), UStatus> {
+        Ok(())
+    }
+
+    async fn receive(
+        &self,
+        _source_filter: &UUri,
+        _sink_filter: Option<&UUri>,
+    ) -> Result<UMessage, UStatus> {
+        Err(UStatus::fail_with_code(
+            UCode::UNIMPLEMENTED,
+            "receive is not used by benchmark fixture",
+        ))
+    }
+
+    async fn register_listener(
+        &self,
+        _source_filter: &UUri,
+        _sink_filter: Option<&UUri>,
+        _listener: Arc<dyn UListener>,
+    ) -> Result<(), UStatus> {
+        Ok(())
+    }
+
+    async fn unregister_listener(
+        &self,
+        _source_filter: &UUri,
+        _sink_filter: Option<&UUri>,
+        _listener: Arc<dyn UListener>,
+    ) -> Result<(), UStatus> {
+        Ok(())
+    }
+}
+
+/// Fixed fixture for `ingress_registry/*` benchmark IDs.
+pub struct IngressRegistryFixture {
+    registry: IngressRouteRegistry,
+    in_transport: Arc<dyn UTransport>,
+    out_sender: broadcast::Sender<Arc<UMessage>>,
+    directory: SubscriptionDirectory,
+    ingress_authority: String,
+    egress_authority: String,
+    route_id: String,
+}
+
+impl IngressRegistryFixture {
+    pub async fn new(subscription_rows: usize) -> Result<Self, UStatus> {
+        let ingress_authority = "authority-a".to_string();
+        let egress_authority = "authority-b".to_string();
+        let directory = directory_from_subscriptions(build_subscriptions(
+            &ingress_authority,
+            &egress_authority,
+            subscription_rows,
+        ))
+        .await?;
+        let (out_sender, _) = broadcast::channel(64);
+
+        Ok(Self {
+            registry: IngressRouteRegistry::new(),
+            in_transport: Arc::new(NoopRegistryTransport),
+            out_sender,
+            directory,
+            ingress_authority,
+            egress_authority,
+            route_id: "benchmark-route".to_string(),
+        })
+    }
+
+    pub async fn register_route(&self) -> bool {
+        self.registry
+            .register_route(
+                self.in_transport.clone(),
+                &self.ingress_authority,
+                &self.egress_authority,
+                &self.route_id,
+                self.out_sender.clone(),
+                &self.directory,
+            )
+            .await
+            .is_ok()
+    }
+
+    pub async fn unregister_route(&self) {
+        self.registry
+            .unregister_route(
+                self.in_transport.clone(),
+                &self.ingress_authority,
+                &self.egress_authority,
+                &self.directory,
+            )
+            .await;
+    }
+}
+
+#[derive(Default)]
+struct CountingDispatchTransport {
+    send_count: AtomicUsize,
+}
+
+impl CountingDispatchTransport {
+    fn sent_count(&self) -> usize {
+        self.send_count.load(Ordering::Relaxed)
+    }
+}
+
+#[async_trait]
+impl UTransport for CountingDispatchTransport {
+    async fn send(&self, _message: UMessage) -> Result<(), UStatus> {
+        self.send_count.fetch_add(1, Ordering::Relaxed);
+        Ok(())
+    }
+
+    async fn receive(
+        &self,
+        _source_filter: &UUri,
+        _sink_filter: Option<&UUri>,
+    ) -> Result<UMessage, UStatus> {
+        Err(UStatus::fail_with_code(
+            UCode::UNIMPLEMENTED,
+            "receive is not used by benchmark fixture",
+        ))
+    }
+
+    async fn register_listener(
+        &self,
+        _source_filter: &UUri,
+        _sink_filter: Option<&UUri>,
+        _listener: Arc<dyn UListener>,
+    ) -> Result<(), UStatus> {
+        Ok(())
+    }
+
+    async fn unregister_listener(
+        &self,
+        _source_filter: &UUri,
+        _sink_filter: Option<&UUri>,
+        _listener: Arc<dyn UListener>,
+    ) -> Result<(), UStatus> {
+        Ok(())
+    }
+}
+
+/// Executes one in-process egress dispatch cycle and returns the send count.
+pub async fn run_single_route_dispatch_once() -> usize {
+    let dispatch_transport = Arc::new(CountingDispatchTransport::default());
+    let out_transport: Arc<dyn UTransport> = dispatch_transport.clone();
+
+    let (sender, receiver) = broadcast::channel(8);
+    sender
+        .send(Arc::new(UMessage::default()))
+        .expect("dispatch channel should accept one message");
+    drop(sender);
+
+    EgressRouteWorker::route_dispatch_loop(
+        "benchmark-egress-dispatch".to_string(),
+        out_transport,
+        receiver,
+    )
+    .await;
+
+    dispatch_transport.sent_count()
+}

--- a/up-streamer/src/lib.rs
+++ b/up-streamer/src/lib.rs
@@ -187,5 +187,8 @@ pub mod observability;
 mod routing;
 mod runtime;
 
+#[doc(hidden)]
+pub mod benchmark_support;
+
 mod ustreamer;
 pub use ustreamer::UStreamer;

--- a/utils/criterion-guardrail/Cargo.toml
+++ b/utils/criterion-guardrail/Cargo.toml
@@ -1,0 +1,31 @@
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+
+[package]
+name = "criterion-guardrail"
+rust-version.workspace = true
+version.workspace = true
+repository.workspace = true
+homepage.workspace = true
+edition.workspace = true
+keywords.workspace = true
+license.workspace = true
+
+[dependencies]
+chrono = { version = "0.4.39", default-features = true, features = ["clock"] }
+clap = { workspace = true, features = ["derive"] }
+csv = { version = "1.3.1" }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+walkdir = { version = "2.5.0" }
+
+[dev-dependencies]
+tempfile = { version = "3.14.0" }

--- a/utils/criterion-guardrail/src/lib.rs
+++ b/utils/criterion-guardrail/src/lib.rs
@@ -1,0 +1,664 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+use chrono::Utc;
+use serde::Serialize;
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use walkdir::WalkDir;
+
+pub const REQUIRED_BENCHMARK_IDS: [&str; 6] = [
+    "routing_lookup/exact_authority",
+    "routing_lookup/wildcard_authority",
+    "publish_resolution/source_filter_derivation",
+    "ingress_registry/register_route",
+    "ingress_registry/unregister_route",
+    "egress_forwarding/single_route_dispatch",
+];
+
+const THROUGHPUT_GROUPS: [&str; 2] = ["egress_forwarding", "ingress_registry"];
+const LATENCY_GROUPS: [&str; 2] = ["routing_lookup", "publish_resolution"];
+const ALLOC_PROXY_BENCHMARK_IDS: [&str; 2] = [
+    "routing_lookup/wildcard_authority",
+    "publish_resolution/source_filter_derivation",
+];
+
+const REQUIRED_HEADER_COLUMNS: [&str; 2] = ["sample_measured_value", "iteration_count"];
+
+#[derive(Clone, Debug)]
+pub struct GuardrailInput {
+    pub criterion_root: PathBuf,
+    pub baseline: String,
+    pub candidate: String,
+    pub throughput_threshold_pct: f64,
+    pub latency_threshold_pct: f64,
+    pub alloc_proxy_threshold_pct: f64,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct ThresholdConfig {
+    pub throughput_threshold_pct: f64,
+    pub latency_threshold_pct: f64,
+    pub alloc_proxy_threshold_pct: f64,
+}
+
+#[derive(Clone, Copy, Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MetricKind {
+    Throughput,
+    Latency,
+    AllocProxy,
+}
+
+impl MetricKind {
+    fn as_label(self) -> &'static str {
+        match self {
+            Self::Throughput => "throughput",
+            Self::Latency => "latency",
+            Self::AllocProxy => "alloc_proxy",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct BenchmarkResult {
+    pub benchmark_id: String,
+    pub metric_kind: MetricKind,
+    pub baseline_ns_per_iter: f64,
+    pub candidate_ns_per_iter: f64,
+    pub delta_pct: f64,
+    pub threshold_pct: f64,
+    pub pass: bool,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct GuardrailReport {
+    pub timestamp_utc: String,
+    pub criterion_root: String,
+    pub baseline: String,
+    pub candidate: String,
+    pub thresholds: ThresholdConfig,
+    pub pass: bool,
+    pub failures: Vec<String>,
+    pub results: Vec<BenchmarkResult>,
+}
+
+pub fn evaluate_guardrail(input: &GuardrailInput) -> Result<GuardrailReport, String> {
+    let baseline_map = discover_named_raw_csvs(&input.criterion_root, &input.baseline)?;
+    let candidate_map = discover_named_raw_csvs(&input.criterion_root, &input.candidate)?;
+
+    let mut missing_ids = Vec::new();
+    for benchmark_id in REQUIRED_BENCHMARK_IDS {
+        if !baseline_map.contains_key(benchmark_id) {
+            missing_ids.push(format!("{benchmark_id} (missing baseline CSV)"));
+        }
+        if !candidate_map.contains_key(benchmark_id) {
+            missing_ids.push(format!("{benchmark_id} (missing candidate CSV)"));
+        }
+    }
+
+    if !missing_ids.is_empty() {
+        return Err(format!(
+            "missing required benchmark IDs in criterion data: {}. Ensure `{}` and `{}` exist under `{}` using Criterion baseline naming and the required benchmark IDs.",
+            missing_ids.join(", "),
+            input.baseline,
+            input.candidate,
+            input.criterion_root.display()
+        ));
+    }
+
+    let thresholds = ThresholdConfig {
+        throughput_threshold_pct: input.throughput_threshold_pct,
+        latency_threshold_pct: input.latency_threshold_pct,
+        alloc_proxy_threshold_pct: input.alloc_proxy_threshold_pct,
+    };
+
+    let mut results = Vec::with_capacity(REQUIRED_BENCHMARK_IDS.len());
+    let mut failures = Vec::new();
+
+    for benchmark_id in REQUIRED_BENCHMARK_IDS {
+        let baseline_path = baseline_map
+            .get(benchmark_id)
+            .ok_or_else(|| format!("internal error: baseline missing for `{benchmark_id}`"))?;
+        let candidate_path = candidate_map
+            .get(benchmark_id)
+            .ok_or_else(|| format!("internal error: candidate missing for `{benchmark_id}`"))?;
+
+        let baseline_ns_per_iter = parse_median_ns_per_iter(baseline_path)?;
+        let candidate_ns_per_iter = parse_median_ns_per_iter(candidate_path)?;
+
+        let (metric_kind, threshold_pct) = benchmark_threshold(benchmark_id, &thresholds)?;
+        let delta_pct = match metric_kind {
+            MetricKind::Throughput => {
+                throughput_delta_pct(baseline_ns_per_iter, candidate_ns_per_iter)?
+            }
+            MetricKind::Latency | MetricKind::AllocProxy => {
+                latency_delta_pct(baseline_ns_per_iter, candidate_ns_per_iter)?
+            }
+        };
+
+        let pass = delta_pct <= threshold_pct;
+        if !pass {
+            failures.push(format!(
+                "{benchmark_id}: regression {delta_pct:.3}% exceeds threshold {threshold_pct:.3}%"
+            ));
+        }
+
+        results.push(BenchmarkResult {
+            benchmark_id: benchmark_id.to_string(),
+            metric_kind,
+            baseline_ns_per_iter,
+            candidate_ns_per_iter,
+            delta_pct,
+            threshold_pct,
+            pass,
+        });
+    }
+
+    let pass = failures.is_empty();
+    Ok(GuardrailReport {
+        timestamp_utc: Utc::now().to_rfc3339(),
+        criterion_root: input.criterion_root.display().to_string(),
+        baseline: input.baseline.clone(),
+        candidate: input.candidate.clone(),
+        thresholds,
+        pass,
+        failures,
+        results,
+    })
+}
+
+pub fn write_report(report: &GuardrailReport, report_path: &Path) -> Result<(), String> {
+    if let Some(parent) = report_path.parent() {
+        fs::create_dir_all(parent).map_err(|err| {
+            format!(
+                "failed to create report parent directory `{}`: {err}",
+                parent.display()
+            )
+        })?;
+    }
+
+    let payload = serde_json::to_string_pretty(report)
+        .map_err(|err| format!("failed to serialize guardrail JSON report: {err}"))?;
+    fs::write(report_path, payload).map_err(|err| {
+        format!(
+            "failed to write guardrail JSON report to `{}`: {err}",
+            report_path.display()
+        )
+    })
+}
+
+pub fn render_summary_table(report: &GuardrailReport) -> String {
+    let mut lines = Vec::with_capacity(report.results.len() + 4);
+    lines.push(format!(
+        "{:<48} {:>12} {:>12} {:>10} {:>10} {:>10}",
+        "benchmark_id", "baseline_ns", "candidate_ns", "delta_%", "threshold", "result"
+    ));
+    lines.push("-".repeat(108));
+
+    for result in &report.results {
+        lines.push(format!(
+            "{:<48} {:>12.3} {:>12.3} {:>10.3} {:>10.3} {:>10}",
+            format!(
+                "{} ({})",
+                result.benchmark_id,
+                result.metric_kind.as_label()
+            ),
+            result.baseline_ns_per_iter,
+            result.candidate_ns_per_iter,
+            result.delta_pct,
+            result.threshold_pct,
+            if result.pass { "PASS" } else { "FAIL" }
+        ));
+    }
+
+    lines.join("\n")
+}
+
+fn benchmark_threshold(
+    benchmark_id: &str,
+    thresholds: &ThresholdConfig,
+) -> Result<(MetricKind, f64), String> {
+    if ALLOC_PROXY_BENCHMARK_IDS.contains(&benchmark_id) {
+        return Ok((MetricKind::AllocProxy, thresholds.alloc_proxy_threshold_pct));
+    }
+
+    let group = benchmark_id
+        .split('/')
+        .next()
+        .ok_or_else(|| format!("invalid benchmark id `{benchmark_id}`"))?;
+
+    if THROUGHPUT_GROUPS.contains(&group) {
+        return Ok((MetricKind::Throughput, thresholds.throughput_threshold_pct));
+    }
+
+    if LATENCY_GROUPS.contains(&group) {
+        return Ok((MetricKind::Latency, thresholds.latency_threshold_pct));
+    }
+
+    Err(format!(
+        "benchmark group `{group}` is not mapped to a threshold for `{benchmark_id}`"
+    ))
+}
+
+fn latency_delta_pct(baseline_ns_per_iter: f64, candidate_ns_per_iter: f64) -> Result<f64, String> {
+    if baseline_ns_per_iter <= 0.0 {
+        return Err("baseline ns/iter must be > 0 for latency delta".to_string());
+    }
+    Ok(((candidate_ns_per_iter - baseline_ns_per_iter) / baseline_ns_per_iter) * 100.0)
+}
+
+fn throughput_delta_pct(
+    baseline_ns_per_iter: f64,
+    candidate_ns_per_iter: f64,
+) -> Result<f64, String> {
+    if baseline_ns_per_iter <= 0.0 || candidate_ns_per_iter <= 0.0 {
+        return Err("baseline and candidate ns/iter must be > 0 for throughput delta".to_string());
+    }
+
+    let baseline_ops = 1_000_000_000.0 / baseline_ns_per_iter;
+    let candidate_ops = 1_000_000_000.0 / candidate_ns_per_iter;
+    Ok(((baseline_ops - candidate_ops) / baseline_ops) * 100.0)
+}
+
+fn parse_median_ns_per_iter(csv_path: &Path) -> Result<f64, String> {
+    let mut reader = csv::ReaderBuilder::new()
+        .has_headers(true)
+        .from_path(csv_path)
+        .map_err(|err| format!("failed to open `{}`: {err}", csv_path.display()))?;
+
+    let headers = reader
+        .headers()
+        .map_err(|err| {
+            format!(
+                "failed to read CSV headers from `{}`: {err}",
+                csv_path.display()
+            )
+        })?
+        .clone();
+
+    for required_column in REQUIRED_HEADER_COLUMNS {
+        if !headers.iter().any(|column| column == required_column) {
+            return Err(format!(
+                "unsupported Criterion raw.csv header layout in `{}`; missing required column `{required_column}`. Expected headers to include `sample_measured_value` and `iteration_count` for the pinned Criterion output.",
+                csv_path.display()
+            ));
+        }
+    }
+
+    let measured_index = headers
+        .iter()
+        .position(|column| column == "sample_measured_value")
+        .ok_or_else(|| {
+            format!(
+                "internal header index error for `sample_measured_value` in `{}`",
+                csv_path.display()
+            )
+        })?;
+    let iteration_index = headers
+        .iter()
+        .position(|column| column == "iteration_count")
+        .ok_or_else(|| {
+            format!(
+                "internal header index error for `iteration_count` in `{}`",
+                csv_path.display()
+            )
+        })?;
+
+    let mut samples_ns_per_iter = Vec::new();
+    for record in reader.records() {
+        let row = record.map_err(|err| {
+            format!(
+                "failed to parse CSV row from `{}`: {err}",
+                csv_path.display()
+            )
+        })?;
+
+        let measured_value = row
+            .get(measured_index)
+            .ok_or_else(|| {
+                format!(
+                    "CSV row in `{}` is missing `sample_measured_value` at expected index",
+                    csv_path.display()
+                )
+            })?
+            .parse::<f64>()
+            .map_err(|err| {
+                format!(
+                    "failed to parse `sample_measured_value` in `{}`: {err}",
+                    csv_path.display()
+                )
+            })?;
+
+        let iteration_count = row
+            .get(iteration_index)
+            .ok_or_else(|| {
+                format!(
+                    "CSV row in `{}` is missing `iteration_count` at expected index",
+                    csv_path.display()
+                )
+            })?
+            .parse::<f64>()
+            .map_err(|err| {
+                format!(
+                    "failed to parse `iteration_count` in `{}`: {err}",
+                    csv_path.display()
+                )
+            })?;
+
+        if iteration_count <= 0.0 {
+            return Err(format!(
+                "invalid `iteration_count` <= 0 in `{}`",
+                csv_path.display()
+            ));
+        }
+
+        samples_ns_per_iter.push(measured_value / iteration_count);
+    }
+
+    if samples_ns_per_iter.is_empty() {
+        return Err(format!(
+            "no benchmark samples found in `{}`",
+            csv_path.display()
+        ));
+    }
+
+    samples_ns_per_iter.sort_by(|left, right| left.total_cmp(right));
+    Ok(median(&samples_ns_per_iter))
+}
+
+fn median(sorted_values: &[f64]) -> f64 {
+    let len = sorted_values.len();
+    if len % 2 == 1 {
+        sorted_values[len / 2]
+    } else {
+        (sorted_values[(len / 2) - 1] + sorted_values[len / 2]) / 2.0
+    }
+}
+
+fn discover_named_raw_csvs(
+    criterion_root: &Path,
+    comparison_name: &str,
+) -> Result<HashMap<String, PathBuf>, String> {
+    if !criterion_root.is_dir() {
+        return Err(format!(
+            "criterion root `{}` does not exist or is not a directory",
+            criterion_root.display()
+        ));
+    }
+
+    let mut discovered = HashMap::new();
+    for entry in WalkDir::new(criterion_root) {
+        let entry = entry.map_err(|err| {
+            format!(
+                "failed to walk criterion directory `{}`: {err}",
+                criterion_root.display()
+            )
+        })?;
+
+        if !entry.file_type().is_file() || entry.file_name() != "raw.csv" {
+            continue;
+        }
+
+        let Some((benchmark_id, csv_path, is_direct_layout)) =
+            classify_named_raw_csv_path(criterion_root, entry.path(), comparison_name)?
+        else {
+            continue;
+        };
+
+        match discovered.get(&benchmark_id) {
+            None => {
+                discovered.insert(benchmark_id, csv_path);
+            }
+            Some(existing_path) => {
+                if is_direct_layout && existing_path.to_string_lossy().contains("/new/raw.csv") {
+                    discovered.insert(benchmark_id, csv_path);
+                }
+            }
+        }
+    }
+
+    Ok(discovered)
+}
+
+fn classify_named_raw_csv_path(
+    criterion_root: &Path,
+    csv_path: &Path,
+    comparison_name: &str,
+) -> Result<Option<(String, PathBuf, bool)>, String> {
+    let Some(parent) = csv_path.parent() else {
+        return Ok(None);
+    };
+
+    let mut benchmark_dir = None;
+    let mut is_direct_layout = false;
+
+    if parent
+        .file_name()
+        .is_some_and(|component| component == comparison_name)
+    {
+        benchmark_dir = parent.parent();
+        is_direct_layout = true;
+    } else if parent
+        .file_name()
+        .is_some_and(|component| component == "new")
+        && parent
+            .parent()
+            .and_then(|path| path.file_name())
+            .is_some_and(|component| component == comparison_name)
+    {
+        benchmark_dir = parent.parent().and_then(|path| path.parent());
+    }
+
+    let Some(benchmark_dir) = benchmark_dir else {
+        return Ok(None);
+    };
+
+    let relative = benchmark_dir.strip_prefix(criterion_root).map_err(|err| {
+        format!(
+            "failed to derive benchmark id from `{}` under criterion root `{}`: {err}",
+            benchmark_dir.display(),
+            criterion_root.display()
+        )
+    })?;
+
+    let benchmark_id = relative
+        .iter()
+        .map(|component| component.to_string_lossy().to_string())
+        .collect::<Vec<_>>()
+        .join("/");
+
+    if benchmark_id.is_empty() {
+        return Ok(None);
+    }
+
+    Ok(Some((
+        benchmark_id,
+        csv_path.to_path_buf(),
+        is_direct_layout,
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        evaluate_guardrail, parse_median_ns_per_iter, GuardrailInput, REQUIRED_BENCHMARK_IDS,
+    };
+    use std::fs;
+    use std::path::Path;
+    use tempfile::TempDir;
+
+    const HEADER: &str = "group,function,value,sample_measured_value,unit,iteration_count\n";
+
+    fn write_raw_csv(path: &Path, measured_values: &[u64], iteration_count: u64) {
+        let mut payload = String::from(HEADER);
+        for measured_value in measured_values {
+            payload.push_str(&format!(
+                "routing,bench,id,{measured_value},ns,{iteration_count}\n"
+            ));
+        }
+
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("create fixture parent directories");
+        }
+        fs::write(path, payload).expect("write fixture csv");
+    }
+
+    fn write_all_required_benchmark_ids(
+        criterion_root: &Path,
+        baseline: &str,
+        candidate: &str,
+        candidate_multiplier_pct: f64,
+    ) {
+        for benchmark_id in REQUIRED_BENCHMARK_IDS {
+            let baseline_path = criterion_root
+                .join(benchmark_id)
+                .join(baseline)
+                .join("raw.csv");
+            let candidate_path = criterion_root
+                .join(benchmark_id)
+                .join(candidate)
+                .join("raw.csv");
+
+            write_raw_csv(&baseline_path, &[1000, 1020, 980], 10);
+            let candidate_sample = (1000.0 * candidate_multiplier_pct) as u64;
+            write_raw_csv(
+                &candidate_path,
+                &[
+                    candidate_sample,
+                    candidate_sample + 5,
+                    candidate_sample + 10,
+                ],
+                10,
+            );
+        }
+    }
+
+    #[test]
+    fn parse_median_uses_sample_over_iteration_count_ratio() {
+        let tempdir = TempDir::new().expect("tempdir");
+        let csv_path = tempdir.path().join("ratio/raw.csv");
+
+        write_raw_csv(&csv_path, &[1000, 1200, 1100], 10);
+
+        let median = parse_median_ns_per_iter(&csv_path).expect("csv should parse");
+        assert!((median - 110.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn parse_median_rejects_schema_without_required_headers() {
+        let tempdir = TempDir::new().expect("tempdir");
+        let csv_path = tempdir.path().join("invalid/raw.csv");
+
+        if let Some(parent) = csv_path.parent() {
+            fs::create_dir_all(parent).expect("create parent");
+        }
+        fs::write(
+            &csv_path,
+            "group,function,value,sample_measured_value,unit\nrouting,bench,id,1000,ns\n",
+        )
+        .expect("write invalid csv");
+
+        let parse_err = parse_median_ns_per_iter(&csv_path).expect_err("should fail on schema");
+        assert!(parse_err.contains("unsupported Criterion raw.csv header layout"));
+    }
+
+    #[test]
+    fn evaluate_guardrail_returns_error_for_missing_required_benchmark_id() {
+        let tempdir = TempDir::new().expect("tempdir");
+        let criterion_root = tempdir.path().join("criterion");
+        let baseline = "ergonomics_baseline";
+        let candidate = "ergonomics_candidate";
+
+        let benchmark_id = REQUIRED_BENCHMARK_IDS[0];
+        write_raw_csv(
+            &criterion_root
+                .join(benchmark_id)
+                .join(baseline)
+                .join("raw.csv"),
+            &[1000, 1010, 1020],
+            10,
+        );
+        write_raw_csv(
+            &criterion_root
+                .join(benchmark_id)
+                .join(candidate)
+                .join("raw.csv"),
+            &[1000, 1010, 1020],
+            10,
+        );
+
+        let err = evaluate_guardrail(&GuardrailInput {
+            criterion_root,
+            baseline: baseline.to_string(),
+            candidate: candidate.to_string(),
+            throughput_threshold_pct: 3.0,
+            latency_threshold_pct: 5.0,
+            alloc_proxy_threshold_pct: 5.0,
+        })
+        .expect_err("missing benchmark IDs should fail");
+
+        assert!(err.contains("missing required benchmark IDs"));
+    }
+
+    #[test]
+    fn evaluate_guardrail_reports_threshold_breach_without_parse_failure() {
+        let tempdir = TempDir::new().expect("tempdir");
+        let criterion_root = tempdir.path().join("criterion");
+        let baseline = "ergonomics_baseline";
+        let candidate = "ergonomics_candidate";
+
+        write_all_required_benchmark_ids(&criterion_root, baseline, candidate, 1.20);
+
+        let report = evaluate_guardrail(&GuardrailInput {
+            criterion_root,
+            baseline: baseline.to_string(),
+            candidate: candidate.to_string(),
+            throughput_threshold_pct: 3.0,
+            latency_threshold_pct: 5.0,
+            alloc_proxy_threshold_pct: 5.0,
+        })
+        .expect("schema is valid");
+
+        assert!(!report.pass, "20% regression must fail thresholds");
+        assert!(!report.failures.is_empty());
+        assert!(report.results.iter().any(|result| !result.pass));
+    }
+
+    #[test]
+    fn evaluate_guardrail_passes_when_candidate_is_within_thresholds() {
+        let tempdir = TempDir::new().expect("tempdir");
+        let criterion_root = tempdir.path().join("criterion");
+        let baseline = "ergonomics_baseline";
+        let candidate = "ergonomics_candidate";
+
+        write_all_required_benchmark_ids(&criterion_root, baseline, candidate, 1.01);
+
+        let report = evaluate_guardrail(&GuardrailInput {
+            criterion_root,
+            baseline: baseline.to_string(),
+            candidate: candidate.to_string(),
+            throughput_threshold_pct: 3.0,
+            latency_threshold_pct: 5.0,
+            alloc_proxy_threshold_pct: 5.0,
+        })
+        .expect("schema is valid");
+
+        assert!(
+            report.pass,
+            "1% regression should pass configured thresholds"
+        );
+        assert!(report.failures.is_empty());
+    }
+}

--- a/utils/criterion-guardrail/src/main.rs
+++ b/utils/criterion-guardrail/src/main.rs
@@ -1,0 +1,76 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+use clap::Parser;
+use criterion_guardrail::{evaluate_guardrail, render_summary_table, write_report, GuardrailInput};
+use std::path::PathBuf;
+
+#[derive(Debug, Parser)]
+#[command(name = "criterion-guardrail")]
+#[command(about = "Evaluate Criterion baseline/candidate thresholds")]
+struct Cli {
+    #[arg(long)]
+    criterion_root: PathBuf,
+    #[arg(long)]
+    baseline: String,
+    #[arg(long)]
+    candidate: String,
+    #[arg(long)]
+    throughput_threshold_pct: f64,
+    #[arg(long)]
+    latency_threshold_pct: f64,
+    #[arg(long)]
+    alloc_proxy_threshold_pct: f64,
+    #[arg(long)]
+    report: PathBuf,
+}
+
+fn main() {
+    let cli = Cli::parse();
+    let input = GuardrailInput {
+        criterion_root: cli.criterion_root,
+        baseline: cli.baseline,
+        candidate: cli.candidate,
+        throughput_threshold_pct: cli.throughput_threshold_pct,
+        latency_threshold_pct: cli.latency_threshold_pct,
+        alloc_proxy_threshold_pct: cli.alloc_proxy_threshold_pct,
+    };
+
+    let report = match evaluate_guardrail(&input) {
+        Ok(report) => report,
+        Err(err) => {
+            eprintln!("criterion-guardrail: {err}");
+            std::process::exit(1);
+        }
+    };
+
+    println!("{}", render_summary_table(&report));
+
+    if let Err(err) = write_report(&report, &cli.report) {
+        eprintln!("criterion-guardrail: {err}");
+        std::process::exit(1);
+    }
+
+    println!("JSON report: {}", cli.report.display());
+
+    if report.pass {
+        println!("criterion-guardrail: PASS");
+        std::process::exit(0);
+    }
+
+    eprintln!("criterion-guardrail: FAIL (threshold breach)");
+    for failure in report.failures {
+        eprintln!("- {failure}");
+    }
+    std::process::exit(2);
+}

--- a/utils/criterion-guardrail/tests/fixture_tree.rs
+++ b/utils/criterion-guardrail/tests/fixture_tree.rs
@@ -1,0 +1,36 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+use criterion_guardrail::{evaluate_guardrail, GuardrailInput, REQUIRED_BENCHMARK_IDS};
+use std::path::PathBuf;
+
+#[test]
+fn checked_in_fixture_tree_supports_direct_and_fallback_layouts() {
+    let criterion_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("criterion-sample-tree");
+
+    let report = evaluate_guardrail(&GuardrailInput {
+        criterion_root,
+        baseline: "ergonomics_baseline".to_string(),
+        candidate: "ergonomics_candidate".to_string(),
+        throughput_threshold_pct: 3.0,
+        latency_threshold_pct: 5.0,
+        alloc_proxy_threshold_pct: 5.0,
+    })
+    .expect("fixture tree should parse");
+
+    assert!(report.pass);
+    assert_eq!(report.results.len(), REQUIRED_BENCHMARK_IDS.len());
+}

--- a/utils/criterion-guardrail/tests/fixtures/criterion-sample-tree/egress_forwarding/single_route_dispatch/ergonomics_baseline/raw.csv
+++ b/utils/criterion-guardrail/tests/fixtures/criterion-sample-tree/egress_forwarding/single_route_dispatch/ergonomics_baseline/raw.csv
@@ -1,0 +1,4 @@
+group,function,value,sample_measured_value,unit,iteration_count
+egress_forwarding,single_route_dispatch,single_route_dispatch,1000,ns,10
+egress_forwarding,single_route_dispatch,single_route_dispatch,1010,ns,10
+egress_forwarding,single_route_dispatch,single_route_dispatch,990,ns,10

--- a/utils/criterion-guardrail/tests/fixtures/criterion-sample-tree/egress_forwarding/single_route_dispatch/ergonomics_candidate/new/raw.csv
+++ b/utils/criterion-guardrail/tests/fixtures/criterion-sample-tree/egress_forwarding/single_route_dispatch/ergonomics_candidate/new/raw.csv
@@ -1,0 +1,4 @@
+group,function,value,sample_measured_value,unit,iteration_count
+egress_forwarding,single_route_dispatch,single_route_dispatch,1020,ns,10
+egress_forwarding,single_route_dispatch,single_route_dispatch,1030,ns,10
+egress_forwarding,single_route_dispatch,single_route_dispatch,1010,ns,10

--- a/utils/criterion-guardrail/tests/fixtures/criterion-sample-tree/ingress_registry/register_route/ergonomics_baseline/raw.csv
+++ b/utils/criterion-guardrail/tests/fixtures/criterion-sample-tree/ingress_registry/register_route/ergonomics_baseline/raw.csv
@@ -1,0 +1,4 @@
+group,function,value,sample_measured_value,unit,iteration_count
+ingress_registry,register_route,register_route,1000,ns,10
+ingress_registry,register_route,register_route,1010,ns,10
+ingress_registry,register_route,register_route,990,ns,10

--- a/utils/criterion-guardrail/tests/fixtures/criterion-sample-tree/ingress_registry/register_route/ergonomics_candidate/new/raw.csv
+++ b/utils/criterion-guardrail/tests/fixtures/criterion-sample-tree/ingress_registry/register_route/ergonomics_candidate/new/raw.csv
@@ -1,0 +1,4 @@
+group,function,value,sample_measured_value,unit,iteration_count
+ingress_registry,register_route,register_route,1020,ns,10
+ingress_registry,register_route,register_route,1030,ns,10
+ingress_registry,register_route,register_route,1010,ns,10

--- a/utils/criterion-guardrail/tests/fixtures/criterion-sample-tree/ingress_registry/unregister_route/ergonomics_baseline/raw.csv
+++ b/utils/criterion-guardrail/tests/fixtures/criterion-sample-tree/ingress_registry/unregister_route/ergonomics_baseline/raw.csv
@@ -1,0 +1,4 @@
+group,function,value,sample_measured_value,unit,iteration_count
+ingress_registry,unregister_route,unregister_route,1000,ns,10
+ingress_registry,unregister_route,unregister_route,1010,ns,10
+ingress_registry,unregister_route,unregister_route,990,ns,10

--- a/utils/criterion-guardrail/tests/fixtures/criterion-sample-tree/ingress_registry/unregister_route/ergonomics_candidate/new/raw.csv
+++ b/utils/criterion-guardrail/tests/fixtures/criterion-sample-tree/ingress_registry/unregister_route/ergonomics_candidate/new/raw.csv
@@ -1,0 +1,4 @@
+group,function,value,sample_measured_value,unit,iteration_count
+ingress_registry,unregister_route,unregister_route,1020,ns,10
+ingress_registry,unregister_route,unregister_route,1030,ns,10
+ingress_registry,unregister_route,unregister_route,1010,ns,10

--- a/utils/criterion-guardrail/tests/fixtures/criterion-sample-tree/publish_resolution/source_filter_derivation/ergonomics_baseline/raw.csv
+++ b/utils/criterion-guardrail/tests/fixtures/criterion-sample-tree/publish_resolution/source_filter_derivation/ergonomics_baseline/raw.csv
@@ -1,0 +1,4 @@
+group,function,value,sample_measured_value,unit,iteration_count
+publish_resolution,source_filter_derivation,source_filter_derivation,1000,ns,10
+publish_resolution,source_filter_derivation,source_filter_derivation,1010,ns,10
+publish_resolution,source_filter_derivation,source_filter_derivation,990,ns,10

--- a/utils/criterion-guardrail/tests/fixtures/criterion-sample-tree/publish_resolution/source_filter_derivation/ergonomics_candidate/new/raw.csv
+++ b/utils/criterion-guardrail/tests/fixtures/criterion-sample-tree/publish_resolution/source_filter_derivation/ergonomics_candidate/new/raw.csv
@@ -1,0 +1,4 @@
+group,function,value,sample_measured_value,unit,iteration_count
+publish_resolution,source_filter_derivation,source_filter_derivation,1040,ns,10
+publish_resolution,source_filter_derivation,source_filter_derivation,1030,ns,10
+publish_resolution,source_filter_derivation,source_filter_derivation,1050,ns,10

--- a/utils/criterion-guardrail/tests/fixtures/criterion-sample-tree/routing_lookup/exact_authority/ergonomics_baseline/raw.csv
+++ b/utils/criterion-guardrail/tests/fixtures/criterion-sample-tree/routing_lookup/exact_authority/ergonomics_baseline/raw.csv
@@ -1,0 +1,4 @@
+group,function,value,sample_measured_value,unit,iteration_count
+routing_lookup,exact_authority,exact_authority,1000,ns,10
+routing_lookup,exact_authority,exact_authority,1010,ns,10
+routing_lookup,exact_authority,exact_authority,990,ns,10

--- a/utils/criterion-guardrail/tests/fixtures/criterion-sample-tree/routing_lookup/exact_authority/ergonomics_candidate/new/raw.csv
+++ b/utils/criterion-guardrail/tests/fixtures/criterion-sample-tree/routing_lookup/exact_authority/ergonomics_candidate/new/raw.csv
@@ -1,0 +1,4 @@
+group,function,value,sample_measured_value,unit,iteration_count
+routing_lookup,exact_authority,exact_authority,1040,ns,10
+routing_lookup,exact_authority,exact_authority,1030,ns,10
+routing_lookup,exact_authority,exact_authority,1050,ns,10

--- a/utils/criterion-guardrail/tests/fixtures/criterion-sample-tree/routing_lookup/wildcard_authority/ergonomics_baseline/raw.csv
+++ b/utils/criterion-guardrail/tests/fixtures/criterion-sample-tree/routing_lookup/wildcard_authority/ergonomics_baseline/raw.csv
@@ -1,0 +1,4 @@
+group,function,value,sample_measured_value,unit,iteration_count
+routing_lookup,wildcard_authority,wildcard_authority,1000,ns,10
+routing_lookup,wildcard_authority,wildcard_authority,1010,ns,10
+routing_lookup,wildcard_authority,wildcard_authority,990,ns,10

--- a/utils/criterion-guardrail/tests/fixtures/criterion-sample-tree/routing_lookup/wildcard_authority/ergonomics_candidate/new/raw.csv
+++ b/utils/criterion-guardrail/tests/fixtures/criterion-sample-tree/routing_lookup/wildcard_authority/ergonomics_candidate/new/raw.csv
@@ -1,0 +1,4 @@
+group,function,value,sample_measured_value,unit,iteration_count
+routing_lookup,wildcard_authority,wildcard_authority,1040,ns,10
+routing_lookup,wildcard_authority,wildcard_authority,1030,ns,10
+routing_lookup,wildcard_authority,wildcard_authority,1050,ns,10


### PR DESCRIPTION
## Why
- This PR introduces a deterministic Criterion benchmark layer so ergonomics-focused refactors in `up-streamer` can be evaluated with an explicit regression gate instead of ad-hoc interpretation.
- The `criterion-guardrail` CLI exists to make baseline-vs-candidate threshold checks machine-checkable and reproducible in local workflows.
- It is intentionally a hotspot microbenchmark guardrail; it is not a replacement for transport smoke validations or a claim of absolute cross-machine performance.

## What This Adds
- Deterministic benchmark support and benchmark IDs in `up-streamer`:
  - `up-streamer/src/benchmark_support.rs`
  - `up-streamer/benches/streamer_criterion.rs`
- Guardrail CLI crate and tests:
  - `utils/criterion-guardrail/src/lib.rs`
  - `utils/criterion-guardrail/src/main.rs`
  - `utils/criterion-guardrail/tests/**`
- Reproducible bench orchestration script:
  - `scripts/bench_streamer_criterion.sh`
- Advisory CI workflow and artifacts:
  - `.github/workflows/benchmark-guardrail-advisory.yaml`
- Developer-facing usage and rationale docs:
  - `up-streamer/README.md`

Guardrail evaluation behavior:
- Reads baseline/candidate Criterion `raw.csv` outputs.
- Computes median `sample_measured_value / iteration_count` (`ns/iter`) per required benchmark ID.
- Applies configured regression thresholds and exits non-zero on threshold breach.
- Emits both human-readable table output and a JSON report artifact.

## What This Does Not Do
- Does not replace end-to-end transport smoke/perf validation.
- Does not promote CI guardrail from advisory to required/failing mode.
- Does not redesign benchmark algorithms or alter threshold policy in this PR.

## How To Run Locally
```bash
export CRITERION_ARGS="--sample-size 60 --warm-up-time 3 --measurement-time 12 --noise-threshold 0.02"
if command -v taskset >/dev/null; then export BENCH_PIN_PREFIX="taskset -c 2"; else export BENCH_PIN_PREFIX=""; fi

scripts/bench_streamer_criterion.sh baseline
scripts/bench_streamer_criterion.sh candidate ergonomics_candidate_slice_a
scripts/bench_streamer_criterion.sh guardrail ergonomics_candidate_slice_a "$OPENCODE_CONFIG_DIR/reports/ergonomics-perf/bench-data/criterion-guardrail.json"
scripts/bench_streamer_criterion.sh export
```

## CI Mode (Advisory)
- Workflow: `.github/workflows/benchmark-guardrail-advisory.yaml`
- Baseline/candidate benchmark runs execute in CI.
- Guardrail and export steps are advisory (`continue-on-error: true`).
- Guardrail JSON and bencher compare text are uploaded as artifacts for reviewer inspection.
- Why advisory-first: benchmark checks are sensitive to shared-runner variance; this keeps performance signal visible without introducing flaky merge blockers.
- Promotion intent: move to required/failing mode after stability evidence is established:
  - at least 20 consecutive CI runs with complete guardrail artifacts,
  - unchanged-commit replay false-positive rate <= 5%,
  - per-benchmark p95 run-to-run variance <= 2%.

## Stack Context
- Current PR: #84 (benchmark layer)
- Target branch: `main`
- Depends on: #83
- Review order: #83 -> #84 -> #85
- Dependent PR: #85
- Incremental review scope: compare against PR #83 to isolate benchmark-only additions.

## Validation
- PASS: `source build/envsetup.sh highest && cargo check -p criterion-guardrail --all-targets`
- PASS: `source build/envsetup.sh highest && cargo test -p criterion-guardrail --all-targets`
- PASS: `source build/envsetup.sh highest && cargo check -p up-streamer --benches`
- PASS: `source build/envsetup.sh highest && cargo test --workspace`
- PASS: `source build/envsetup.sh highest && cargo clippy --all-targets -- -W warnings -D warnings`
- PASS: `source build/envsetup.sh highest && env -u VSOMEIP_INSTALL_PATH cargo clippy --features vsomeip-transport,bundled-vsomeip,zenoh-transport,mqtt-transport --all-targets -- -W warnings -D warnings`
- SKIP (environment): unbundled clippy because `VSOMEIP_INSTALL_PATH` is unset/invalid after `source build/envsetup.sh highest`