### PR TITLE
smoke: deterministic transport smoke suite (c5)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+utils/transport-smoke-suite/tests/fixtures/** linguist-generated=true
+utils/transport-smoke-suite/claims/** linguist-generated=true

--- a/.github/workflows/transport-smoke-capstone.yaml
+++ b/.github/workflows/transport-smoke-capstone.yaml
@@ -1,0 +1,82 @@
+# ********************************************************************************
+#  Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************/
+
+name: Transport Smoke Capstone
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 3 * * *"
+
+concurrency:
+  group: transport-smoke-capstone
+  cancel-in-progress: false
+
+jobs:
+  mqtt-smoke:
+    name: MQTT transport smoke matrix
+    runs-on: ubuntu-22.04
+    timeout-minutes: 45
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y build-essential cmake libboost-all-dev libclang-dev pkg-config libssl-dev
+
+      - name: Run MQTT scenario subset
+        run: |
+          cargo run -p transport-smoke-suite --bin transport-smoke-matrix -- \
+            --only smoke-zenoh-mqtt-rr-zenoh-client-mqtt-service \
+            --only smoke-zenoh-mqtt-rr-mqtt-client-zenoh-service \
+            --only smoke-zenoh-mqtt-ps-zenoh-publisher-mqtt-subscriber \
+            --only smoke-zenoh-mqtt-ps-mqtt-publisher-zenoh-subscriber \
+            --artifacts-root target/transport-smoke/ci-mqtt
+
+      - name: Upload MQTT artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: transport-smoke-mqtt
+          path: target/transport-smoke/ci-mqtt
+          retention-days: 14
+
+  someip-smoke:
+    name: SOME/IP transport smoke matrix
+    runs-on: ubuntu-22.04
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y build-essential cmake libboost-all-dev libclang-dev pkg-config libssl-dev
+
+      - name: Run SOME/IP scenario subset (bundled profile)
+        run: |
+          cargo run -p transport-smoke-suite --bin transport-smoke-matrix -- \
+            --only smoke-zenoh-someip-rr-zenoh-client-someip-service \
+            --only smoke-zenoh-someip-rr-someip-client-zenoh-service \
+            --only smoke-zenoh-someip-ps-zenoh-publisher-someip-subscriber \
+            --only smoke-zenoh-someip-ps-someip-publisher-zenoh-subscriber \
+            --artifacts-root target/transport-smoke/ci-someip
+
+      - name: Upload SOME/IP artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: transport-smoke-someip
+          path: target/transport-smoke/ci-someip
+          retention-days: 14

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,7 +332,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "955e602d2d68b79ca5d674984259234fad2c8d869ad99011699e0a3cd76f38cd"
 dependencies = [
  "autocxx-engine",
- "env_logger 0.9.3",
+ "env_logger",
  "indexmap 1.9.3",
  "syn 2.0.114",
 ]
@@ -1289,19 +1289,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_logger"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
-dependencies = [
- "humantime",
- "is-terminal",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1362,14 +1349,13 @@ dependencies = [
  "async-trait",
  "chrono",
  "clap",
- "env_logger 0.10.2",
  "hello-world-protos",
  "json5",
- "log",
  "protobuf",
  "serde",
  "tokio",
  "tracing",
+ "tracing-subscriber",
  "up-rust",
  "up-transport-mqtt5",
  "up-transport-vsomeip",
@@ -4924,6 +4910,22 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-serde",
+]
+
+[[package]]
+name = "transport-smoke-suite"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "clap",
+ "libc",
+ "regex",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "walkdir",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "utils/integration-test-utils",
     "example-streamer-implementations",
     "utils/criterion-guardrail",
+    "utils/transport-smoke-suite",
     "configurable-streamer",
     "up-linux-streamer-plugin",
     "up-streamer",
@@ -35,10 +36,8 @@ license = "Apache-2.0"
 [workspace.dependencies]
 async-trait = { version = "0.1" }
 clap = { version = "4.5" }
-env_logger = { version = "0.10.1" }
 futures = { version = "0.3.30" }
 lazy_static = { version = "1.5.0" }
-log = { version = "0.4.20" }
 json5 = { version = "0.4.1" }
 serde = { version = "1.0.154", features = ["derive"] }
 serde_json = { version = "1.0.94" }

--- a/example-streamer-uses/Cargo.toml
+++ b/example-streamer-uses/Cargo.toml
@@ -77,14 +77,13 @@ mqtt-transport = ["up-transport-mqtt5"]
 async-trait = { workspace = true }
 chrono = { version = "0.4" }
 clap = { version = "4.5.9", features = ["derive"] }
-env_logger = { version = "0.10.2" }
 hello-world-protos = { path = "../utils/hello-world-protos" }
-log = { workspace = true }
 json5 = { workspace = true }
 protobuf = { workspace = true }
 serde = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 up-rust = { workspace = true }
 up-transport-zenoh = { workspace = true, optional = true }
 up-transport-vsomeip = { workspace = true, optional = true }

--- a/example-streamer-uses/README.md
+++ b/example-streamer-uses/README.md
@@ -95,6 +95,15 @@ Transport-specific flags:
 - Zenoh binaries: `--endpoint` (existing behavior, now composed with URI overrides)
 - SOME/IP binaries: `--vsomeip-config` and `--remote-authority`
 
+Deterministic sender controls (active client/publisher binaries only):
+
+- `--send-count <n>`
+  - `0` (default) preserves existing infinite-send behavior
+  - any value `>0` performs a bounded send run and then exits
+- `--send-interval-ms <ms>`
+  - defaults to `1000`
+  - controls delay between sends for bounded and unbounded runs
+
 Running with no extra flags keeps prior behavior (defaults are aligned with previous constants).
 
 ### Numeric formats

--- a/example-streamer-uses/src/bin/mqtt_client.rs
+++ b/example-streamer-uses/src/bin/mqtt_client.rs
@@ -130,7 +130,7 @@ async fn main() -> Result<(), UStatus> {
         tokio::time::sleep(Duration::from_millis(args.send_interval_ms)).await;
 
         let hello_request = HelloRequest {
-            name: format!("mqtt_client@i={}", i).to_string(),
+            name: format!("mqtt_client@i={}", i),
             ..Default::default()
         };
         i += 1;

--- a/example-streamer-uses/src/bin/mqtt_client.rs
+++ b/example-streamer-uses/src/bin/mqtt_client.rs
@@ -17,9 +17,9 @@ use clap::Parser;
 use common::cli;
 use common::ServiceResponseListener;
 use hello_world_protos::hello_world_service::HelloRequest;
-use log::info;
 use std::sync::Arc;
 use std::time::Duration;
+use tracing::info;
 use up_rust::{UListener, UMessageBuilder, UStatus, UTransport};
 use up_transport_mqtt5::{Mqtt5Transport, Mqtt5TransportOptions, MqttClientOptions};
 
@@ -67,11 +67,17 @@ struct Args {
     /// MQTT broker URI in host:port format
     #[arg(long, default_value = DEFAULT_BROKER_URI)]
     broker_uri: String,
+    /// Number of requests to send before exiting (0 means run forever)
+    #[arg(long, default_value_t = 0)]
+    send_count: u64,
+    /// Milliseconds to wait between request sends
+    #[arg(long, default_value_t = 1000)]
+    send_interval_ms: u64,
 }
 
 #[tokio::main]
 async fn main() -> Result<(), UStatus> {
-    env_logger::init();
+    let _ = tracing_subscriber::fmt::try_init();
 
     let args = Args::parse();
 
@@ -113,9 +119,15 @@ async fn main() -> Result<(), UStatus> {
         .register_listener(&sink, Some(&source), service_response_listener)
         .await?;
 
-    let mut i = 0;
+    let mut i: u64 = 0;
+    let mut sent_count: u64 = 0;
     loop {
-        tokio::time::sleep(Duration::from_millis(1000)).await;
+        if args.send_count > 0 && sent_count >= args.send_count {
+            info!("Completed bounded send run: sent_count={sent_count}");
+            break;
+        }
+
+        tokio::time::sleep(Duration::from_millis(args.send_interval_ms)).await;
 
         let hello_request = HelloRequest {
             name: format!("mqtt_client@i={}", i).to_string(),
@@ -129,5 +141,8 @@ async fn main() -> Result<(), UStatus> {
         info!("Sending Request message:\n{request_msg:?}");
 
         client.send(request_msg).await?;
+        sent_count += 1;
     }
+
+    Ok(())
 }

--- a/example-streamer-uses/src/bin/mqtt_service.rs
+++ b/example-streamer-uses/src/bin/mqtt_service.rs
@@ -16,9 +16,9 @@ mod common;
 use clap::Parser;
 use common::cli;
 use common::ServiceRequestResponder;
-use log::info;
 use std::sync::Arc;
 use std::thread;
+use tracing::info;
 use up_rust::{UListener, UStatus, UTransport, UUri};
 use up_transport_mqtt5::{Mqtt5Transport, Mqtt5TransportOptions, MqttClientOptions};
 
@@ -50,7 +50,7 @@ struct Args {
 
 #[tokio::main]
 async fn main() -> Result<(), UStatus> {
-    env_logger::init();
+    let _ = tracing_subscriber::fmt::try_init();
 
     let args = Args::parse();
 
@@ -88,6 +88,8 @@ async fn main() -> Result<(), UStatus> {
             service_request_responder.clone(),
         )
         .await?;
+
+    println!("READY listener_registered");
 
     thread::park();
     Ok(())

--- a/example-streamer-uses/src/bin/mqtt_subscriber.rs
+++ b/example-streamer-uses/src/bin/mqtt_subscriber.rs
@@ -16,9 +16,9 @@ mod common;
 use clap::Parser;
 use common::cli;
 use common::PublishReceiver;
-use log::info;
 use std::sync::Arc;
 use std::thread;
+use tracing::info;
 use up_rust::{UListener, UStatus, UTransport};
 use up_transport_mqtt5::{Mqtt5Transport, Mqtt5TransportOptions, MqttClientOptions};
 
@@ -66,7 +66,7 @@ struct Args {
 
 #[tokio::main]
 async fn main() -> Result<(), UStatus> {
-    env_logger::init();
+    let _ = tracing_subscriber::fmt::try_init();
 
     let args = Args::parse();
 
@@ -110,6 +110,8 @@ async fn main() -> Result<(), UStatus> {
     subscriber
         .register_listener(&source_filter, None, publish_receiver.clone())
         .await?;
+
+    println!("READY listener_registered");
 
     thread::park();
     Ok(())

--- a/example-streamer-uses/src/bin/mqtt_subscriber.rs
+++ b/example-streamer-uses/src/bin/mqtt_subscriber.rs
@@ -97,11 +97,8 @@ async fn main() -> Result<(), UStatus> {
         mqtt_client_options,
         ..Default::default()
     };
-    let mqtt5_transport = Mqtt5Transport::new(
-        mqtt_transport_options,
-        local_uuri.authority_name().to_string(),
-    )
-    .await?;
+    let mqtt5_transport =
+        Mqtt5Transport::new(mqtt_transport_options, local_uuri.authority_name()).await?;
     mqtt5_transport.connect().await?;
 
     let subscriber: Arc<dyn UTransport> = Arc::new(mqtt5_transport);

--- a/example-streamer-uses/src/bin/someip_client.rs
+++ b/example-streamer-uses/src/bin/someip_client.rs
@@ -146,7 +146,7 @@ async fn main() -> Result<(), UStatus> {
         tokio::time::sleep(Duration::from_millis(args.send_interval_ms)).await;
 
         let hello_request = HelloRequest {
-            name: format!("me_client@i={}", i).to_string(),
+            name: format!("me_client@i={}", i),
             ..Default::default()
         };
         i += 1;

--- a/example-streamer-uses/src/bin/someip_publisher.rs
+++ b/example-streamer-uses/src/bin/someip_publisher.rs
@@ -19,9 +19,9 @@ use clap::Parser;
 use common::cli;
 use hello_world_protos::hello_world_topics::Timer;
 use hello_world_protos::timeofday::TimeOfDay;
-use log::{info, trace, warn};
 use std::sync::Arc;
 use std::time::Duration;
+use tracing::{info, trace, warn};
 use up_rust::{UMessageBuilder, UStatus, UTransport};
 use up_transport_vsomeip::UPTransportVsomeip;
 
@@ -57,11 +57,17 @@ struct Args {
     /// Path to the vsomeip JSON configuration file
     #[arg(long, default_value = DEFAULT_VSOMEIP_CONFIG)]
     vsomeip_config: String,
+    /// Number of publish messages to send before exiting (0 means run forever)
+    #[arg(long, default_value_t = 0)]
+    send_count: u64,
+    /// Milliseconds to wait between publish sends
+    #[arg(long, default_value_t = 1000)]
+    send_interval_ms: u64,
 }
 
 #[tokio::main]
 async fn main() -> Result<(), UStatus> {
-    env_logger::init();
+    let _ = tracing_subscriber::fmt::try_init();
 
     let args = Args::parse();
 
@@ -96,8 +102,14 @@ async fn main() -> Result<(), UStatus> {
 
     let source = cli::build_uuri(&args.uauthority, uentity, uversion, resource)?;
 
+    let mut sent_count: u64 = 0;
     loop {
-        tokio::time::sleep(Duration::from_millis(1000)).await;
+        if args.send_count > 0 && sent_count >= args.send_count {
+            info!("Completed bounded send run: sent_count={sent_count}");
+            break;
+        }
+
+        tokio::time::sleep(Duration::from_millis(args.send_interval_ms)).await;
 
         let now = Local::now();
 
@@ -120,5 +132,8 @@ async fn main() -> Result<(), UStatus> {
         info!("Sending Publish message:\n{publish_msg:?}");
 
         publisher.send(publish_msg).await?;
+        sent_count += 1;
     }
+
+    Ok(())
 }

--- a/example-streamer-uses/src/bin/someip_service.rs
+++ b/example-streamer-uses/src/bin/someip_service.rs
@@ -16,9 +16,9 @@ mod common;
 use clap::Parser;
 use common::cli;
 use common::ServiceRequestResponder;
-use log::{info, trace, warn};
 use std::sync::Arc;
 use std::thread;
+use tracing::{info, trace, warn};
 use up_rust::{UListener, UStatus, UTransport, UUri};
 use up_transport_vsomeip::UPTransportVsomeip;
 
@@ -58,7 +58,7 @@ struct Args {
 
 #[tokio::main]
 async fn main() -> Result<(), UStatus> {
-    env_logger::init();
+    let _ = tracing_subscriber::fmt::try_init();
 
     let args = Args::parse();
 
@@ -103,6 +103,8 @@ async fn main() -> Result<(), UStatus> {
             service_request_responder.clone(),
         )
         .await?;
+
+    println!("READY listener_registered");
 
     thread::park();
     Ok(())

--- a/example-streamer-uses/src/bin/someip_subscriber.rs
+++ b/example-streamer-uses/src/bin/someip_subscriber.rs
@@ -16,9 +16,9 @@ mod common;
 use clap::Parser;
 use common::cli;
 use common::PublishReceiver;
-use log::{trace, warn};
 use std::sync::Arc;
 use std::thread;
+use tracing::{trace, warn};
 use up_rust::{UListener, UStatus, UTransport};
 use up_transport_vsomeip::UPTransportVsomeip;
 
@@ -74,7 +74,7 @@ struct Args {
 
 #[tokio::main]
 async fn main() -> Result<(), UStatus> {
-    env_logger::init();
+    let _ = tracing_subscriber::fmt::try_init();
 
     let args = Args::parse();
 
@@ -123,6 +123,8 @@ async fn main() -> Result<(), UStatus> {
     subscriber
         .register_listener(&source_filter, None, publish_receiver.clone())
         .await?;
+
+    println!("READY listener_registered");
 
     thread::park();
     Ok(())

--- a/example-streamer-uses/src/bin/zenoh_client.rs
+++ b/example-streamer-uses/src/bin/zenoh_client.rs
@@ -17,10 +17,10 @@ use clap::Parser;
 use common::cli;
 use common::ServiceResponseListener;
 use hello_world_protos::hello_world_service::HelloRequest;
-use log::{debug, info};
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
+use tracing::{debug, info};
 use up_rust::{UListener, UMessageBuilder, UStatus, UTransport};
 use up_transport_zenoh::{
     zenoh_config::{Config, EndPoint},
@@ -69,11 +69,17 @@ struct Args {
     /// Resource ID for target service URI (decimal or 0x-prefixed hex)
     #[arg(long, default_value = DEFAULT_TARGET_RESOURCE)]
     target_resource: String,
+    /// Number of requests to send before exiting (0 means run forever)
+    #[arg(long, default_value_t = 0)]
+    send_count: u64,
+    /// Milliseconds to wait between request sends
+    #[arg(long, default_value_t = 1000)]
+    send_interval_ms: u64,
 }
 
 #[tokio::main]
 async fn main() -> Result<(), UStatus> {
-    env_logger::init();
+    let _ = tracing_subscriber::fmt::try_init();
 
     let args = Args::parse();
 
@@ -122,9 +128,15 @@ async fn main() -> Result<(), UStatus> {
         .register_listener(&sink, Some(&source), service_response_listener)
         .await?;
 
-    let mut i = 0;
+    let mut i: u64 = 0;
+    let mut sent_count: u64 = 0;
     loop {
-        tokio::time::sleep(Duration::from_millis(1000)).await;
+        if args.send_count > 0 && sent_count >= args.send_count {
+            info!("Completed bounded send run: sent_count={sent_count}");
+            break;
+        }
+
+        tokio::time::sleep(Duration::from_millis(args.send_interval_ms)).await;
 
         let hello_request = HelloRequest {
             name: format!("ue_client@i={}", i).to_string(),
@@ -139,5 +151,8 @@ async fn main() -> Result<(), UStatus> {
         info!("Sending Request message:\n{:?}", &request_msg);
 
         client.send(request_msg).await?;
+        sent_count += 1;
     }
+
+    Ok(())
 }

--- a/example-streamer-uses/src/bin/zenoh_client.rs
+++ b/example-streamer-uses/src/bin/zenoh_client.rs
@@ -139,7 +139,7 @@ async fn main() -> Result<(), UStatus> {
         tokio::time::sleep(Duration::from_millis(args.send_interval_ms)).await;
 
         let hello_request = HelloRequest {
-            name: format!("ue_client@i={}", i).to_string(),
+            name: format!("ue_client@i={}", i),
             ..Default::default()
         };
         i += 1;

--- a/example-streamer-uses/src/bin/zenoh_service.rs
+++ b/example-streamer-uses/src/bin/zenoh_service.rs
@@ -16,10 +16,10 @@ mod common;
 use clap::Parser;
 use common::cli;
 use common::ServiceRequestResponder;
-use log::info;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::thread;
+use tracing::info;
 use up_rust::{UListener, UStatus, UTransport, UUri};
 use up_transport_zenoh::{
     zenoh_config::{Config, EndPoint},
@@ -54,7 +54,7 @@ struct Args {
 
 #[tokio::main]
 async fn main() -> Result<(), UStatus> {
-    env_logger::init();
+    let _ = tracing_subscriber::fmt::try_init();
 
     let args = Args::parse();
 
@@ -101,6 +101,8 @@ async fn main() -> Result<(), UStatus> {
             service_request_responder.clone(),
         )
         .await?;
+
+    println!("READY listener_registered");
 
     thread::park();
     Ok(())

--- a/example-streamer-uses/src/bin/zenoh_subscriber.rs
+++ b/example-streamer-uses/src/bin/zenoh_subscriber.rs
@@ -16,10 +16,10 @@ mod common;
 use clap::Parser;
 use common::cli;
 use common::PublishReceiver;
-use log::info;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::thread;
+use tracing::info;
 use up_rust::{UListener, UStatus, UTransport};
 use up_transport_zenoh::{
     zenoh_config::{Config, EndPoint},
@@ -70,7 +70,7 @@ struct Args {
 
 #[tokio::main]
 async fn main() -> Result<(), UStatus> {
-    env_logger::init();
+    let _ = tracing_subscriber::fmt::try_init();
 
     let args = Args::parse();
 
@@ -119,6 +119,8 @@ async fn main() -> Result<(), UStatus> {
     subscriber
         .register_listener(&source_filter, None, publish_receiver.clone())
         .await?;
+
+    println!("READY listener_registered");
 
     thread::park();
     Ok(())

--- a/utils/transport-smoke-suite/Cargo.toml
+++ b/utils/transport-smoke-suite/Cargo.toml
@@ -1,0 +1,34 @@
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+
+[package]
+name = "transport-smoke-suite"
+rust-version.workspace = true
+version.workspace = true
+repository.workspace = true
+homepage.workspace = true
+edition.workspace = true
+keywords.workspace = true
+license.workspace = true
+
+[dependencies]
+anyhow = { version = "1.0.98" }
+chrono = { version = "0.4.40", default-features = true, features = ["clock", "serde"] }
+clap = { workspace = true, features = ["derive", "env"] }
+libc = { version = "0.2.171" }
+regex = { version = "1.11.1" }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+tokio = { workspace = true, features = ["fs", "io-util", "macros", "process", "rt", "rt-multi-thread", "signal", "time"] }
+walkdir = { version = "2.5.0" }
+
+[dev-dependencies]
+tempfile = { version = "3.19.1" }

--- a/utils/transport-smoke-suite/claims/smoke-zenoh-mqtt-ps-mqtt-publisher-zenoh-subscriber.json
+++ b/utils/transport-smoke-suite/claims/smoke-zenoh-mqtt-ps-mqtt-publisher-zenoh-subscriber.json
@@ -1,0 +1,74 @@
+{
+  "schema_version": "1.0",
+  "scenario_id": "smoke-zenoh-mqtt-ps-mqtt-publisher-zenoh-subscriber",
+  "claims": [
+    {
+      "claim_id": "publisher_sent_messages",
+      "category": "endpoint_communication",
+      "kind": "must_match",
+      "file": "publisher.log",
+      "pattern": "Sending Publish message",
+      "threshold": "endpoint_communication"
+    },
+    {
+      "claim_id": "subscriber_received_messages",
+      "category": "endpoint_communication",
+      "kind": "must_match",
+      "file": "subscriber.log",
+      "pattern": "PublishReceiver: Received a message",
+      "threshold": "endpoint_communication"
+    },
+    {
+      "claim_id": "streamer_egress_send_attempt",
+      "category": "streamer_egress",
+      "kind": "must_match",
+      "file": "streamer.log",
+      "pattern": "egress_send_attempt",
+      "threshold": "egress_send_attempt"
+    },
+    {
+      "claim_id": "streamer_egress_send_ok",
+      "category": "streamer_egress",
+      "kind": "must_match",
+      "file": "streamer.log",
+      "pattern": "egress_send_ok",
+      "threshold": "egress_send_ok"
+    },
+    {
+      "claim_id": "streamer_egress_worker_create_or_reuse",
+      "category": "streamer_egress",
+      "kind": "must_match",
+      "file": "streamer.log",
+      "pattern": "egress_worker_create|egress_worker_reuse",
+      "threshold": "egress_worker_create_or_reuse"
+    },
+    {
+      "claim_id": "streamer_no_panic",
+      "category": "forbidden_signature",
+      "kind": "must_not_match",
+      "file": "streamer.log",
+      "pattern": "panicked at"
+    },
+    {
+      "claim_id": "streamer_no_egress_send_failed",
+      "category": "forbidden_signature",
+      "kind": "must_not_match",
+      "file": "streamer.log",
+      "pattern": "egress_send_failed"
+    },
+    {
+      "claim_id": "publisher_no_panic",
+      "category": "forbidden_signature",
+      "kind": "must_not_match",
+      "file": "publisher.log",
+      "pattern": "panicked at"
+    },
+    {
+      "claim_id": "subscriber_no_panic",
+      "category": "forbidden_signature",
+      "kind": "must_not_match",
+      "file": "subscriber.log",
+      "pattern": "panicked at"
+    }
+  ]
+}

--- a/utils/transport-smoke-suite/claims/smoke-zenoh-mqtt-ps-zenoh-publisher-mqtt-subscriber.json
+++ b/utils/transport-smoke-suite/claims/smoke-zenoh-mqtt-ps-zenoh-publisher-mqtt-subscriber.json
@@ -1,0 +1,74 @@
+{
+  "schema_version": "1.0",
+  "scenario_id": "smoke-zenoh-mqtt-ps-zenoh-publisher-mqtt-subscriber",
+  "claims": [
+    {
+      "claim_id": "publisher_sent_messages",
+      "category": "endpoint_communication",
+      "kind": "must_match",
+      "file": "publisher.log",
+      "pattern": "Sending Publish message",
+      "threshold": "endpoint_communication"
+    },
+    {
+      "claim_id": "subscriber_received_messages",
+      "category": "endpoint_communication",
+      "kind": "must_match",
+      "file": "subscriber.log",
+      "pattern": "PublishReceiver: Received a message",
+      "threshold": "endpoint_communication"
+    },
+    {
+      "claim_id": "streamer_egress_send_attempt",
+      "category": "streamer_egress",
+      "kind": "must_match",
+      "file": "streamer.log",
+      "pattern": "egress_send_attempt",
+      "threshold": "egress_send_attempt"
+    },
+    {
+      "claim_id": "streamer_egress_send_ok",
+      "category": "streamer_egress",
+      "kind": "must_match",
+      "file": "streamer.log",
+      "pattern": "egress_send_ok",
+      "threshold": "egress_send_ok"
+    },
+    {
+      "claim_id": "streamer_egress_worker_create_or_reuse",
+      "category": "streamer_egress",
+      "kind": "must_match",
+      "file": "streamer.log",
+      "pattern": "egress_worker_create|egress_worker_reuse",
+      "threshold": "egress_worker_create_or_reuse"
+    },
+    {
+      "claim_id": "streamer_no_panic",
+      "category": "forbidden_signature",
+      "kind": "must_not_match",
+      "file": "streamer.log",
+      "pattern": "panicked at"
+    },
+    {
+      "claim_id": "streamer_no_egress_send_failed",
+      "category": "forbidden_signature",
+      "kind": "must_not_match",
+      "file": "streamer.log",
+      "pattern": "egress_send_failed"
+    },
+    {
+      "claim_id": "publisher_no_panic",
+      "category": "forbidden_signature",
+      "kind": "must_not_match",
+      "file": "publisher.log",
+      "pattern": "panicked at"
+    },
+    {
+      "claim_id": "subscriber_no_panic",
+      "category": "forbidden_signature",
+      "kind": "must_not_match",
+      "file": "subscriber.log",
+      "pattern": "panicked at"
+    }
+  ]
+}

--- a/utils/transport-smoke-suite/claims/smoke-zenoh-mqtt-rr-mqtt-client-zenoh-service.json
+++ b/utils/transport-smoke-suite/claims/smoke-zenoh-mqtt-rr-mqtt-client-zenoh-service.json
@@ -1,0 +1,74 @@
+{
+  "schema_version": "1.0",
+  "scenario_id": "smoke-zenoh-mqtt-rr-mqtt-client-zenoh-service",
+  "claims": [
+    {
+      "claim_id": "client_response_evidence",
+      "category": "endpoint_communication",
+      "kind": "must_match",
+      "file": "client.log",
+      "pattern": "ServiceResponseListener: Received a message|UMESSAGE_TYPE_RESPONSE",
+      "threshold": "endpoint_communication"
+    },
+    {
+      "claim_id": "service_request_response_evidence",
+      "category": "endpoint_communication",
+      "kind": "must_match",
+      "file": "service.log",
+      "pattern": "ServiceResponseListener: Received a message|Sending Response message",
+      "threshold": "endpoint_communication"
+    },
+    {
+      "claim_id": "streamer_egress_send_attempt",
+      "category": "streamer_egress",
+      "kind": "must_match",
+      "file": "streamer.log",
+      "pattern": "egress_send_attempt",
+      "threshold": "egress_send_attempt"
+    },
+    {
+      "claim_id": "streamer_egress_send_ok",
+      "category": "streamer_egress",
+      "kind": "must_match",
+      "file": "streamer.log",
+      "pattern": "egress_send_ok",
+      "threshold": "egress_send_ok"
+    },
+    {
+      "claim_id": "streamer_egress_worker_create_or_reuse",
+      "category": "streamer_egress",
+      "kind": "must_match",
+      "file": "streamer.log",
+      "pattern": "egress_worker_create|egress_worker_reuse",
+      "threshold": "egress_worker_create_or_reuse"
+    },
+    {
+      "claim_id": "streamer_no_panic",
+      "category": "forbidden_signature",
+      "kind": "must_not_match",
+      "file": "streamer.log",
+      "pattern": "panicked at"
+    },
+    {
+      "claim_id": "streamer_no_egress_send_failed",
+      "category": "forbidden_signature",
+      "kind": "must_not_match",
+      "file": "streamer.log",
+      "pattern": "egress_send_failed"
+    },
+    {
+      "claim_id": "client_no_panic",
+      "category": "forbidden_signature",
+      "kind": "must_not_match",
+      "file": "client.log",
+      "pattern": "panicked at"
+    },
+    {
+      "claim_id": "service_no_panic",
+      "category": "forbidden_signature",
+      "kind": "must_not_match",
+      "file": "service.log",
+      "pattern": "panicked at"
+    }
+  ]
+}

--- a/utils/transport-smoke-suite/claims/smoke-zenoh-mqtt-rr-zenoh-client-mqtt-service.json
+++ b/utils/transport-smoke-suite/claims/smoke-zenoh-mqtt-rr-zenoh-client-mqtt-service.json
@@ -1,0 +1,74 @@
+{
+  "schema_version": "1.0",
+  "scenario_id": "smoke-zenoh-mqtt-rr-zenoh-client-mqtt-service",
+  "claims": [
+    {
+      "claim_id": "client_response_evidence",
+      "category": "endpoint_communication",
+      "kind": "must_match",
+      "file": "client.log",
+      "pattern": "ServiceResponseListener: Received a message|UMESSAGE_TYPE_RESPONSE",
+      "threshold": "endpoint_communication"
+    },
+    {
+      "claim_id": "service_request_response_evidence",
+      "category": "endpoint_communication",
+      "kind": "must_match",
+      "file": "service.log",
+      "pattern": "ServiceResponseListener: Received a message|Sending Response message",
+      "threshold": "endpoint_communication"
+    },
+    {
+      "claim_id": "streamer_egress_send_attempt",
+      "category": "streamer_egress",
+      "kind": "must_match",
+      "file": "streamer.log",
+      "pattern": "egress_send_attempt",
+      "threshold": "egress_send_attempt"
+    },
+    {
+      "claim_id": "streamer_egress_send_ok",
+      "category": "streamer_egress",
+      "kind": "must_match",
+      "file": "streamer.log",
+      "pattern": "egress_send_ok",
+      "threshold": "egress_send_ok"
+    },
+    {
+      "claim_id": "streamer_egress_worker_create_or_reuse",
+      "category": "streamer_egress",
+      "kind": "must_match",
+      "file": "streamer.log",
+      "pattern": "egress_worker_create|egress_worker_reuse",
+      "threshold": "egress_worker_create_or_reuse"
+    },
+    {
+      "claim_id": "streamer_no_panic",
+      "category": "forbidden_signature",
+      "kind": "must_not_match",
+      "file": "streamer.log",
+      "pattern": "panicked at"
+    },
+    {
+      "claim_id": "streamer_no_egress_send_failed",
+      "category": "forbidden_signature",
+      "kind": "must_not_match",
+      "file": "streamer.log",
+      "pattern": "egress_send_failed"
+    },
+    {
+      "claim_id": "client_no_panic",
+      "category": "forbidden_signature",
+      "kind": "must_not_match",
+      "file": "client.log",
+      "pattern": "panicked at"
+    },
+    {
+      "claim_id": "service_no_panic",
+      "category": "forbidden_signature",
+      "kind": "must_not_match",
+      "file": "service.log",
+      "pattern": "panicked at"
+    }
+  ]
+}

--- a/utils/transport-smoke-suite/claims/smoke-zenoh-someip-ps-someip-publisher-zenoh-subscriber.json
+++ b/utils/transport-smoke-suite/claims/smoke-zenoh-someip-ps-someip-publisher-zenoh-subscriber.json
@@ -1,0 +1,81 @@
+{
+  "schema_version": "1.0",
+  "scenario_id": "smoke-zenoh-someip-ps-someip-publisher-zenoh-subscriber",
+  "claims": [
+    {
+      "claim_id": "publisher_sent_messages",
+      "category": "endpoint_communication",
+      "kind": "must_match",
+      "file": "publisher.log",
+      "pattern": "Sending Publish message",
+      "threshold": "endpoint_communication"
+    },
+    {
+      "claim_id": "subscriber_received_messages",
+      "category": "endpoint_communication",
+      "kind": "must_match",
+      "file": "subscriber.log",
+      "pattern": "PublishReceiver: Received a message",
+      "threshold": "endpoint_communication"
+    },
+    {
+      "claim_id": "streamer_egress_send_attempt",
+      "category": "streamer_egress",
+      "kind": "must_match",
+      "file": "streamer.log",
+      "pattern": "egress_send_attempt",
+      "threshold": "egress_send_attempt"
+    },
+    {
+      "claim_id": "streamer_egress_send_ok",
+      "category": "streamer_egress",
+      "kind": "must_match",
+      "file": "streamer.log",
+      "pattern": "egress_send_ok",
+      "threshold": "egress_send_ok"
+    },
+    {
+      "claim_id": "streamer_egress_worker_create_or_reuse",
+      "category": "streamer_egress",
+      "kind": "must_match",
+      "file": "streamer.log",
+      "pattern": "egress_worker_create|egress_worker_reuse",
+      "threshold": "egress_worker_create_or_reuse"
+    },
+    {
+      "claim_id": "streamer_no_missing_route_info",
+      "category": "forbidden_signature",
+      "kind": "must_not_match",
+      "file": "streamer.log",
+      "pattern": "Routing info for remote service could not be found"
+    },
+    {
+      "claim_id": "streamer_no_panic",
+      "category": "forbidden_signature",
+      "kind": "must_not_match",
+      "file": "streamer.log",
+      "pattern": "panicked at"
+    },
+    {
+      "claim_id": "streamer_no_egress_send_failed",
+      "category": "forbidden_signature",
+      "kind": "must_not_match",
+      "file": "streamer.log",
+      "pattern": "egress_send_failed"
+    },
+    {
+      "claim_id": "publisher_no_panic",
+      "category": "forbidden_signature",
+      "kind": "must_not_match",
+      "file": "publisher.log",
+      "pattern": "panicked at"
+    },
+    {
+      "claim_id": "subscriber_no_panic",
+      "category": "forbidden_signature",
+      "kind": "must_not_match",
+      "file": "subscriber.log",
+      "pattern": "panicked at"
+    }
+  ]
+}

--- a/utils/transport-smoke-suite/claims/smoke-zenoh-someip-ps-zenoh-publisher-someip-subscriber.json
+++ b/utils/transport-smoke-suite/claims/smoke-zenoh-someip-ps-zenoh-publisher-someip-subscriber.json
@@ -1,0 +1,81 @@
+{
+  "schema_version": "1.0",
+  "scenario_id": "smoke-zenoh-someip-ps-zenoh-publisher-someip-subscriber",
+  "claims": [
+    {
+      "claim_id": "publisher_sent_messages",
+      "category": "endpoint_communication",
+      "kind": "must_match",
+      "file": "publisher.log",
+      "pattern": "Sending Publish message",
+      "threshold": "endpoint_communication"
+    },
+    {
+      "claim_id": "subscriber_received_messages",
+      "category": "endpoint_communication",
+      "kind": "must_match",
+      "file": "subscriber.log",
+      "pattern": "PublishReceiver: Received a message",
+      "threshold": "endpoint_communication"
+    },
+    {
+      "claim_id": "streamer_egress_send_attempt",
+      "category": "streamer_egress",
+      "kind": "must_match",
+      "file": "streamer.log",
+      "pattern": "egress_send_attempt",
+      "threshold": "egress_send_attempt"
+    },
+    {
+      "claim_id": "streamer_egress_send_ok",
+      "category": "streamer_egress",
+      "kind": "must_match",
+      "file": "streamer.log",
+      "pattern": "egress_send_ok",
+      "threshold": "egress_send_ok"
+    },
+    {
+      "claim_id": "streamer_egress_worker_create_or_reuse",
+      "category": "streamer_egress",
+      "kind": "must_match",
+      "file": "streamer.log",
+      "pattern": "egress_worker_create|egress_worker_reuse",
+      "threshold": "egress_worker_create_or_reuse"
+    },
+    {
+      "claim_id": "streamer_no_missing_route_info",
+      "category": "forbidden_signature",
+      "kind": "must_not_match",
+      "file": "streamer.log",
+      "pattern": "Routing info for remote service could not be found"
+    },
+    {
+      "claim_id": "streamer_no_panic",
+      "category": "forbidden_signature",
+      "kind": "must_not_match",
+      "file": "streamer.log",
+      "pattern": "panicked at"
+    },
+    {
+      "claim_id": "streamer_no_egress_send_failed",
+      "category": "forbidden_signature",
+      "kind": "must_not_match",
+      "file": "streamer.log",
+      "pattern": "egress_send_failed"
+    },
+    {
+      "claim_id": "publisher_no_panic",
+      "category": "forbidden_signature",
+      "kind": "must_not_match",
+      "file": "publisher.log",
+      "pattern": "panicked at"
+    },
+    {
+      "claim_id": "subscriber_no_panic",
+      "category": "forbidden_signature",
+      "kind": "must_not_match",
+      "file": "subscriber.log",
+      "pattern": "panicked at"
+    }
+  ]
+}

--- a/utils/transport-smoke-suite/claims/smoke-zenoh-someip-rr-someip-client-zenoh-service.json
+++ b/utils/transport-smoke-suite/claims/smoke-zenoh-someip-rr-someip-client-zenoh-service.json
@@ -1,0 +1,81 @@
+{
+  "schema_version": "1.0",
+  "scenario_id": "smoke-zenoh-someip-rr-someip-client-zenoh-service",
+  "claims": [
+    {
+      "claim_id": "client_response_evidence",
+      "category": "endpoint_communication",
+      "kind": "must_match",
+      "file": "client.log",
+      "pattern": "UMESSAGE_TYPE_RESPONSE|commstatus: Some\\(OK\\)",
+      "threshold": "endpoint_communication"
+    },
+    {
+      "claim_id": "service_request_response_evidence",
+      "category": "endpoint_communication",
+      "kind": "must_match",
+      "file": "service.log",
+      "pattern": "ServiceResponseListener: Received a message|Sending Response message",
+      "threshold": "endpoint_communication"
+    },
+    {
+      "claim_id": "streamer_egress_send_attempt",
+      "category": "streamer_egress",
+      "kind": "must_match",
+      "file": "streamer.log",
+      "pattern": "egress_send_attempt",
+      "threshold": "egress_send_attempt"
+    },
+    {
+      "claim_id": "streamer_egress_send_ok",
+      "category": "streamer_egress",
+      "kind": "must_match",
+      "file": "streamer.log",
+      "pattern": "egress_send_ok",
+      "threshold": "egress_send_ok"
+    },
+    {
+      "claim_id": "streamer_egress_worker_create_or_reuse",
+      "category": "streamer_egress",
+      "kind": "must_match",
+      "file": "streamer.log",
+      "pattern": "egress_worker_create|egress_worker_reuse",
+      "threshold": "egress_worker_create_or_reuse"
+    },
+    {
+      "claim_id": "streamer_no_missing_route_info",
+      "category": "forbidden_signature",
+      "kind": "must_not_match",
+      "file": "streamer.log",
+      "pattern": "Routing info for remote service could not be found"
+    },
+    {
+      "claim_id": "streamer_no_panic",
+      "category": "forbidden_signature",
+      "kind": "must_not_match",
+      "file": "streamer.log",
+      "pattern": "panicked at"
+    },
+    {
+      "claim_id": "streamer_no_egress_send_failed",
+      "category": "forbidden_signature",
+      "kind": "must_not_match",
+      "file": "streamer.log",
+      "pattern": "egress_send_failed"
+    },
+    {
+      "claim_id": "client_no_panic",
+      "category": "forbidden_signature",
+      "kind": "must_not_match",
+      "file": "client.log",
+      "pattern": "panicked at"
+    },
+    {
+      "claim_id": "service_no_panic",
+      "category": "forbidden_signature",
+      "kind": "must_not_match",
+      "file": "service.log",
+      "pattern": "panicked at"
+    }
+  ]
+}

--- a/utils/transport-smoke-suite/claims/smoke-zenoh-someip-rr-zenoh-client-someip-service.json
+++ b/utils/transport-smoke-suite/claims/smoke-zenoh-someip-rr-zenoh-client-someip-service.json
@@ -1,0 +1,81 @@
+{
+  "schema_version": "1.0",
+  "scenario_id": "smoke-zenoh-someip-rr-zenoh-client-someip-service",
+  "claims": [
+    {
+      "claim_id": "client_response_evidence",
+      "category": "endpoint_communication",
+      "kind": "must_match",
+      "file": "client.log",
+      "pattern": "ServiceResponseListener: Received a message|UMESSAGE_TYPE_RESPONSE",
+      "threshold": "endpoint_communication"
+    },
+    {
+      "claim_id": "service_request_response_evidence",
+      "category": "endpoint_communication",
+      "kind": "must_match",
+      "file": "service.log",
+      "pattern": "ServiceResponseListener: Received a message|Sending Response message",
+      "threshold": "endpoint_communication"
+    },
+    {
+      "claim_id": "streamer_egress_send_attempt",
+      "category": "streamer_egress",
+      "kind": "must_match",
+      "file": "streamer.log",
+      "pattern": "egress_send_attempt",
+      "threshold": "egress_send_attempt"
+    },
+    {
+      "claim_id": "streamer_egress_send_ok",
+      "category": "streamer_egress",
+      "kind": "must_match",
+      "file": "streamer.log",
+      "pattern": "egress_send_ok",
+      "threshold": "egress_send_ok"
+    },
+    {
+      "claim_id": "streamer_egress_worker_create_or_reuse",
+      "category": "streamer_egress",
+      "kind": "must_match",
+      "file": "streamer.log",
+      "pattern": "egress_worker_create|egress_worker_reuse",
+      "threshold": "egress_worker_create_or_reuse"
+    },
+    {
+      "claim_id": "streamer_no_missing_route_info",
+      "category": "forbidden_signature",
+      "kind": "must_not_match",
+      "file": "streamer.log",
+      "pattern": "Routing info for remote service could not be found"
+    },
+    {
+      "claim_id": "streamer_no_panic",
+      "category": "forbidden_signature",
+      "kind": "must_not_match",
+      "file": "streamer.log",
+      "pattern": "panicked at"
+    },
+    {
+      "claim_id": "streamer_no_egress_send_failed",
+      "category": "forbidden_signature",
+      "kind": "must_not_match",
+      "file": "streamer.log",
+      "pattern": "egress_send_failed"
+    },
+    {
+      "claim_id": "client_no_panic",
+      "category": "forbidden_signature",
+      "kind": "must_not_match",
+      "file": "client.log",
+      "pattern": "panicked at"
+    },
+    {
+      "claim_id": "service_no_panic",
+      "category": "forbidden_signature",
+      "kind": "must_not_match",
+      "file": "service.log",
+      "pattern": "panicked at"
+    }
+  ]
+}

--- a/utils/transport-smoke-suite/src/bin/smoke-zenoh-mqtt-ps-mqtt-publisher-zenoh-subscriber.rs
+++ b/utils/transport-smoke-suite/src/bin/smoke-zenoh-mqtt-ps-mqtt-publisher-zenoh-subscriber.rs
@@ -1,0 +1,45 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+use clap::Parser;
+use std::process::ExitCode;
+use transport_smoke_suite::scenario::{run_scenario, ScenarioCliArgs};
+
+const SCENARIO_ID: &str = "smoke-zenoh-mqtt-ps-mqtt-publisher-zenoh-subscriber";
+
+#[derive(Debug, Parser)]
+#[command(name = SCENARIO_ID)]
+#[command(about = "Deterministic smoke scenario: mqtt publisher to zenoh subscriber")]
+struct Cli {
+    #[command(flatten)]
+    common: ScenarioCliArgs,
+}
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    let cli = Cli::parse();
+
+    match run_scenario(SCENARIO_ID, cli.common).await {
+        Ok(result) => {
+            if result.pass {
+                ExitCode::SUCCESS
+            } else {
+                ExitCode::from(1)
+            }
+        }
+        Err(error) => {
+            eprintln!("{SCENARIO_ID} failed: {error:#}");
+            ExitCode::from(2)
+        }
+    }
+}

--- a/utils/transport-smoke-suite/src/bin/smoke-zenoh-mqtt-ps-zenoh-publisher-mqtt-subscriber.rs
+++ b/utils/transport-smoke-suite/src/bin/smoke-zenoh-mqtt-ps-zenoh-publisher-mqtt-subscriber.rs
@@ -1,0 +1,45 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+use clap::Parser;
+use std::process::ExitCode;
+use transport_smoke_suite::scenario::{run_scenario, ScenarioCliArgs};
+
+const SCENARIO_ID: &str = "smoke-zenoh-mqtt-ps-zenoh-publisher-mqtt-subscriber";
+
+#[derive(Debug, Parser)]
+#[command(name = SCENARIO_ID)]
+#[command(about = "Deterministic smoke scenario: zenoh publisher to mqtt subscriber")]
+struct Cli {
+    #[command(flatten)]
+    common: ScenarioCliArgs,
+}
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    let cli = Cli::parse();
+
+    match run_scenario(SCENARIO_ID, cli.common).await {
+        Ok(result) => {
+            if result.pass {
+                ExitCode::SUCCESS
+            } else {
+                ExitCode::from(1)
+            }
+        }
+        Err(error) => {
+            eprintln!("{SCENARIO_ID} failed: {error:#}");
+            ExitCode::from(2)
+        }
+    }
+}

--- a/utils/transport-smoke-suite/src/bin/smoke-zenoh-mqtt-rr-mqtt-client-zenoh-service.rs
+++ b/utils/transport-smoke-suite/src/bin/smoke-zenoh-mqtt-rr-mqtt-client-zenoh-service.rs
@@ -1,0 +1,45 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+use clap::Parser;
+use std::process::ExitCode;
+use transport_smoke_suite::scenario::{run_scenario, ScenarioCliArgs};
+
+const SCENARIO_ID: &str = "smoke-zenoh-mqtt-rr-mqtt-client-zenoh-service";
+
+#[derive(Debug, Parser)]
+#[command(name = SCENARIO_ID)]
+#[command(about = "Deterministic smoke scenario: mqtt client to zenoh service")]
+struct Cli {
+    #[command(flatten)]
+    common: ScenarioCliArgs,
+}
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    let cli = Cli::parse();
+
+    match run_scenario(SCENARIO_ID, cli.common).await {
+        Ok(result) => {
+            if result.pass {
+                ExitCode::SUCCESS
+            } else {
+                ExitCode::from(1)
+            }
+        }
+        Err(error) => {
+            eprintln!("{SCENARIO_ID} failed: {error:#}");
+            ExitCode::from(2)
+        }
+    }
+}

--- a/utils/transport-smoke-suite/src/bin/smoke-zenoh-mqtt-rr-zenoh-client-mqtt-service.rs
+++ b/utils/transport-smoke-suite/src/bin/smoke-zenoh-mqtt-rr-zenoh-client-mqtt-service.rs
@@ -1,0 +1,45 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+use clap::Parser;
+use std::process::ExitCode;
+use transport_smoke_suite::scenario::{run_scenario, ScenarioCliArgs};
+
+const SCENARIO_ID: &str = "smoke-zenoh-mqtt-rr-zenoh-client-mqtt-service";
+
+#[derive(Debug, Parser)]
+#[command(name = SCENARIO_ID)]
+#[command(about = "Deterministic smoke scenario: zenoh client to mqtt service")]
+struct Cli {
+    #[command(flatten)]
+    common: ScenarioCliArgs,
+}
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    let cli = Cli::parse();
+
+    match run_scenario(SCENARIO_ID, cli.common).await {
+        Ok(result) => {
+            if result.pass {
+                ExitCode::SUCCESS
+            } else {
+                ExitCode::from(1)
+            }
+        }
+        Err(error) => {
+            eprintln!("{SCENARIO_ID} failed: {error:#}");
+            ExitCode::from(2)
+        }
+    }
+}

--- a/utils/transport-smoke-suite/src/bin/smoke-zenoh-someip-ps-someip-publisher-zenoh-subscriber.rs
+++ b/utils/transport-smoke-suite/src/bin/smoke-zenoh-someip-ps-someip-publisher-zenoh-subscriber.rs
@@ -1,0 +1,45 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+use clap::Parser;
+use std::process::ExitCode;
+use transport_smoke_suite::scenario::{run_scenario, ScenarioCliArgs};
+
+const SCENARIO_ID: &str = "smoke-zenoh-someip-ps-someip-publisher-zenoh-subscriber";
+
+#[derive(Debug, Parser)]
+#[command(name = SCENARIO_ID)]
+#[command(about = "Deterministic smoke scenario: someip publisher to zenoh subscriber")]
+struct Cli {
+    #[command(flatten)]
+    common: ScenarioCliArgs,
+}
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    let cli = Cli::parse();
+
+    match run_scenario(SCENARIO_ID, cli.common).await {
+        Ok(result) => {
+            if result.pass {
+                ExitCode::SUCCESS
+            } else {
+                ExitCode::from(1)
+            }
+        }
+        Err(error) => {
+            eprintln!("{SCENARIO_ID} failed: {error:#}");
+            ExitCode::from(2)
+        }
+    }
+}

--- a/utils/transport-smoke-suite/src/bin/smoke-zenoh-someip-ps-zenoh-publisher-someip-subscriber.rs
+++ b/utils/transport-smoke-suite/src/bin/smoke-zenoh-someip-ps-zenoh-publisher-someip-subscriber.rs
@@ -1,0 +1,45 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+use clap::Parser;
+use std::process::ExitCode;
+use transport_smoke_suite::scenario::{run_scenario, ScenarioCliArgs};
+
+const SCENARIO_ID: &str = "smoke-zenoh-someip-ps-zenoh-publisher-someip-subscriber";
+
+#[derive(Debug, Parser)]
+#[command(name = SCENARIO_ID)]
+#[command(about = "Deterministic smoke scenario: zenoh publisher to someip subscriber")]
+struct Cli {
+    #[command(flatten)]
+    common: ScenarioCliArgs,
+}
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    let cli = Cli::parse();
+
+    match run_scenario(SCENARIO_ID, cli.common).await {
+        Ok(result) => {
+            if result.pass {
+                ExitCode::SUCCESS
+            } else {
+                ExitCode::from(1)
+            }
+        }
+        Err(error) => {
+            eprintln!("{SCENARIO_ID} failed: {error:#}");
+            ExitCode::from(2)
+        }
+    }
+}

--- a/utils/transport-smoke-suite/src/bin/smoke-zenoh-someip-rr-someip-client-zenoh-service.rs
+++ b/utils/transport-smoke-suite/src/bin/smoke-zenoh-someip-rr-someip-client-zenoh-service.rs
@@ -1,0 +1,45 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+use clap::Parser;
+use std::process::ExitCode;
+use transport_smoke_suite::scenario::{run_scenario, ScenarioCliArgs};
+
+const SCENARIO_ID: &str = "smoke-zenoh-someip-rr-someip-client-zenoh-service";
+
+#[derive(Debug, Parser)]
+#[command(name = SCENARIO_ID)]
+#[command(about = "Deterministic smoke scenario: someip client to zenoh service")]
+struct Cli {
+    #[command(flatten)]
+    common: ScenarioCliArgs,
+}
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    let cli = Cli::parse();
+
+    match run_scenario(SCENARIO_ID, cli.common).await {
+        Ok(result) => {
+            if result.pass {
+                ExitCode::SUCCESS
+            } else {
+                ExitCode::from(1)
+            }
+        }
+        Err(error) => {
+            eprintln!("{SCENARIO_ID} failed: {error:#}");
+            ExitCode::from(2)
+        }
+    }
+}

--- a/utils/transport-smoke-suite/src/bin/smoke-zenoh-someip-rr-zenoh-client-someip-service.rs
+++ b/utils/transport-smoke-suite/src/bin/smoke-zenoh-someip-rr-zenoh-client-someip-service.rs
@@ -1,0 +1,45 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+use clap::Parser;
+use std::process::ExitCode;
+use transport_smoke_suite::scenario::{run_scenario, ScenarioCliArgs};
+
+const SCENARIO_ID: &str = "smoke-zenoh-someip-rr-zenoh-client-someip-service";
+
+#[derive(Debug, Parser)]
+#[command(name = SCENARIO_ID)]
+#[command(about = "Deterministic smoke scenario: zenoh client to someip service")]
+struct Cli {
+    #[command(flatten)]
+    common: ScenarioCliArgs,
+}
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    let cli = Cli::parse();
+
+    match run_scenario(SCENARIO_ID, cli.common).await {
+        Ok(result) => {
+            if result.pass {
+                ExitCode::SUCCESS
+            } else {
+                ExitCode::from(1)
+            }
+        }
+        Err(error) => {
+            eprintln!("{SCENARIO_ID} failed: {error:#}");
+            ExitCode::from(2)
+        }
+    }
+}

--- a/utils/transport-smoke-suite/src/bin/transport-smoke-matrix.rs
+++ b/utils/transport-smoke-suite/src/bin/transport-smoke-matrix.rs
@@ -1,0 +1,377 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+use clap::Parser;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+use std::time::Instant;
+use tokio::process::Command;
+use transport_smoke_suite::claims::{claims_override_kind, ClaimsPathKind};
+use transport_smoke_suite::env;
+use transport_smoke_suite::process::{run_shell_command, shell_escape};
+use transport_smoke_suite::report::{
+    self, FailedScenarioSummary, MatrixScenarioSummary, MatrixSummary, ScenarioReport,
+};
+use transport_smoke_suite::scenario;
+
+#[derive(Debug, Parser)]
+#[command(name = "transport-smoke-matrix")]
+#[command(about = "Run deterministic transport smoke scenarios sequentially")]
+struct Cli {
+    #[arg(long)]
+    all: bool,
+
+    #[arg(long = "only")]
+    only: Vec<String>,
+
+    #[arg(long)]
+    skip_build: bool,
+
+    #[arg(long)]
+    artifacts_root: Option<PathBuf>,
+
+    #[arg(long)]
+    claims_path: Option<PathBuf>,
+
+    #[arg(long, default_value_t = env::DEFAULT_SEND_COUNT)]
+    send_count: u64,
+
+    #[arg(long, default_value_t = env::DEFAULT_SEND_INTERVAL_MS)]
+    send_interval_ms: u64,
+
+    #[arg(long)]
+    scenario_timeout_secs: Option<u64>,
+
+    #[arg(long)]
+    expected_branch: Option<String>,
+
+    #[arg(long)]
+    no_bootstrap: bool,
+
+    #[arg(long, default_value_t = env::DEFAULT_ENDPOINT_CLAIM_MIN_COUNT)]
+    endpoint_claim_min_count: usize,
+
+    #[arg(long, default_value_t = env::DEFAULT_EGRESS_SEND_ATTEMPT_MIN_COUNT)]
+    egress_send_attempt_min_count: usize,
+
+    #[arg(long, default_value_t = env::DEFAULT_EGRESS_SEND_OK_MIN_COUNT)]
+    egress_send_ok_min_count: usize,
+
+    #[arg(long, default_value_t = env::DEFAULT_EGRESS_WORKER_MIN_COUNT)]
+    egress_worker_min_count: usize,
+}
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    let cli = Cli::parse();
+
+    match run(cli).await {
+        Ok(exit_code) => {
+            if exit_code == 0 {
+                ExitCode::SUCCESS
+            } else {
+                ExitCode::from(1)
+            }
+        }
+        Err(error) => {
+            eprintln!("transport-smoke-matrix failed: {error:#}");
+            ExitCode::from(2)
+        }
+    }
+}
+
+async fn run(cli: Cli) -> anyhow::Result<i32> {
+    let repo_root = env::repo_root()?;
+    let expected_branch = env::resolve_expected_branch(cli.expected_branch.clone());
+    env::enforce_expected_branch(&repo_root, expected_branch.as_deref()).await?;
+
+    let selected_scenarios = resolve_selected_scenarios(&cli.only)?;
+    if let Some(claims_path) = cli.claims_path.as_deref() {
+        if claims_override_kind(&repo_root, claims_path)? == ClaimsPathKind::File
+            && selected_scenarios.len() > 1
+        {
+            anyhow::bail!(
+                "--claims-path points to a file but {} scenarios are selected. Use a directory override for multi-scenario matrix runs or select a single scenario with --only",
+                selected_scenarios.len()
+            );
+        }
+    }
+
+    let artifacts_root = env::resolve_artifacts_root(&repo_root, cli.artifacts_root.clone());
+    let matrix_artifact_dir = artifacts_root
+        .join("matrix")
+        .join(env::scenario_timestamp());
+    fs::create_dir_all(&matrix_artifact_dir)?;
+
+    if !cli.skip_build {
+        let outcome = run_shell_command(
+            &repo_root,
+            &repo_root,
+            "cargo build -p transport-smoke-suite --bins",
+            cli.no_bootstrap,
+        )
+        .await?;
+        if outcome.status_code != Some(0) {
+            anyhow::bail!(
+                "failed to build transport-smoke-suite binaries\ncommand: {}\nstdout:\n{}\nstderr:\n{}",
+                outcome.command,
+                outcome.stdout,
+                outcome.stderr
+            );
+        }
+    }
+
+    let matrix_start_wall = chrono::Utc::now();
+    let matrix_start_instant = Instant::now();
+
+    let mut summaries = Vec::new();
+    for scenario_id in &selected_scenarios {
+        let scenario_start = Instant::now();
+        println!("RUNNING {scenario_id}");
+
+        let scenario_run = run_single_scenario(
+            &repo_root,
+            &artifacts_root,
+            scenario_id,
+            &cli,
+            expected_branch.as_deref(),
+        )
+        .await;
+
+        let duration_ms = scenario_start.elapsed().as_millis();
+        let summary = match scenario_run {
+            Ok(report) => build_summary_from_report(report, duration_ms),
+            Err(error) => MatrixScenarioSummary {
+                scenario_id: scenario_id.to_string(),
+                pass: false,
+                exit_code: 1,
+                artifact_dir: None,
+                failure_reason: Some(error.to_string()),
+                duration_ms,
+            },
+        };
+
+        println!(
+            "{} -> {}",
+            summary.scenario_id,
+            if summary.pass { "PASS" } else { "FAIL" }
+        );
+
+        summaries.push(summary);
+    }
+
+    let pass_count = summaries.iter().filter(|summary| summary.pass).count();
+    let fail_count = summaries.len() - pass_count;
+
+    let failed_scenarios = summaries
+        .iter()
+        .filter(|summary| !summary.pass)
+        .map(|summary| FailedScenarioSummary {
+            scenario_id: summary.scenario_id.clone(),
+            failure_reason: summary
+                .failure_reason
+                .clone()
+                .unwrap_or_else(|| "unknown failure".to_string()),
+        })
+        .collect::<Vec<_>>();
+
+    let aggregate_exit_rationale = if fail_count == 0 {
+        "all selected scenarios passed".to_string()
+    } else {
+        format!(
+            "{} of {} scenarios failed; matrix exits non-zero",
+            fail_count,
+            summaries.len()
+        )
+    };
+
+    let matrix_end_wall = chrono::Utc::now();
+    let matrix_summary = MatrixSummary {
+        schema_version: "1.0".to_string(),
+        selected_scenarios,
+        pass_count,
+        fail_count,
+        total_duration_ms: matrix_start_instant.elapsed().as_millis(),
+        scenarios: summaries,
+        failed_scenarios,
+        aggregate_exit_rationale,
+        start_ts: report::timestamp_to_string(matrix_start_wall),
+        end_ts: report::timestamp_to_string(matrix_end_wall),
+    };
+
+    let (matrix_summary_json, matrix_summary_txt) =
+        report::write_matrix_summary(&matrix_summary, &matrix_artifact_dir)?;
+
+    println!("MATRIX_ARTIFACT_DIR={}", matrix_artifact_dir.display());
+    println!("MATRIX_SUMMARY_JSON={}", matrix_summary_json.display());
+    println!("MATRIX_SUMMARY_TXT={}", matrix_summary_txt.display());
+
+    Ok(if fail_count == 0 { 0 } else { 1 })
+}
+
+fn resolve_selected_scenarios(only: &[String]) -> anyhow::Result<Vec<String>> {
+    if only.is_empty() {
+        return Ok(scenario::scenario_ids()
+            .iter()
+            .map(|scenario_id| scenario_id.to_string())
+            .collect());
+    }
+
+    let mut selected = Vec::new();
+    for scenario_id in only {
+        if scenario::scenario_template(scenario_id).is_none() {
+            anyhow::bail!(
+                "unknown scenario id '{}'; valid ids: {}",
+                scenario_id,
+                scenario::scenario_ids().join(", ")
+            );
+        }
+        selected.push(scenario_id.to_string());
+    }
+
+    Ok(selected)
+}
+
+async fn run_single_scenario(
+    repo_root: &Path,
+    artifacts_root: &Path,
+    scenario_id: &str,
+    cli: &Cli,
+    expected_branch: Option<&str>,
+) -> anyhow::Result<ScenarioReport> {
+    let binary_path = repo_root.join("target").join("debug").join(scenario_id);
+
+    if !binary_path.exists() {
+        anyhow::bail!(
+            "scenario binary not found: {}. Build with `cargo build -p transport-smoke-suite --bins`",
+            binary_path.display()
+        );
+    }
+
+    let mut command = Command::new(&binary_path);
+    command.current_dir(repo_root);
+    command.arg("--artifacts-root").arg(artifacts_root);
+    command.arg("--send-count").arg(cli.send_count.to_string());
+    command
+        .arg("--send-interval-ms")
+        .arg(cli.send_interval_ms.to_string());
+    if let Some(claims_path) = &cli.claims_path {
+        command.arg("--claims-path").arg(claims_path);
+    }
+    command
+        .arg("--endpoint-claim-min-count")
+        .arg(cli.endpoint_claim_min_count.to_string());
+    command
+        .arg("--egress-send-attempt-min-count")
+        .arg(cli.egress_send_attempt_min_count.to_string());
+    command
+        .arg("--egress-send-ok-min-count")
+        .arg(cli.egress_send_ok_min_count.to_string());
+    command
+        .arg("--egress-worker-min-count")
+        .arg(cli.egress_worker_min_count.to_string());
+
+    if cli.skip_build {
+        command.arg("--skip-build");
+    }
+    if cli.no_bootstrap {
+        command.arg("--no-bootstrap");
+    }
+    if let Some(scenario_timeout_secs) = cli.scenario_timeout_secs {
+        command
+            .arg("--scenario-timeout-secs")
+            .arg(scenario_timeout_secs.to_string());
+    }
+    if let Some(expected_branch) = expected_branch {
+        command.arg("--expected-branch").arg(expected_branch);
+    }
+
+    let output = command.output().await.map_err(|error| {
+        anyhow::anyhow!("unable to execute scenario '{}': {error}", scenario_id)
+    })?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+
+    let report_json_path = parse_scenario_report_path(&stdout)
+        .or_else(|| parse_scenario_report_path(&stderr))
+        .or_else(|| find_latest_scenario_report(artifacts_root, scenario_id));
+
+    let Some(report_json_path) = report_json_path else {
+        anyhow::bail!(
+            "scenario '{}' did not emit SCENARIO_REPORT_JSON and no report was found under {}\nstdout:\n{}\nstderr:\n{}",
+            scenario_id,
+            shell_escape(&artifacts_root.display().to_string()),
+            stdout,
+            stderr
+        );
+    };
+
+    let report = report::load_scenario_report(&report_json_path)?;
+    if !output.status.success() && report.pass {
+        anyhow::bail!(
+            "scenario '{}' exited non-zero but report marked PASS\nstdout:\n{}\nstderr:\n{}",
+            scenario_id,
+            stdout,
+            stderr
+        );
+    }
+
+    Ok(report)
+}
+
+fn parse_scenario_report_path(output: &str) -> Option<PathBuf> {
+    output
+        .lines()
+        .find_map(|line| line.strip_prefix("SCENARIO_REPORT_JSON="))
+        .map(|value| PathBuf::from(value.trim()))
+}
+
+fn find_latest_scenario_report(artifacts_root: &Path, scenario_id: &str) -> Option<PathBuf> {
+    let scenario_root = artifacts_root.join(scenario_id);
+    if !scenario_root.exists() {
+        return None;
+    }
+
+    let mut candidates = fs::read_dir(&scenario_root)
+        .ok()?
+        .filter_map(|entry| entry.ok())
+        .filter_map(|entry| {
+            let path = entry.path();
+            if !path.is_dir() {
+                return None;
+            }
+            let report_path = path.join("scenario-report.json");
+            if !report_path.exists() {
+                return None;
+            }
+            let directory_name = path.file_name()?.to_string_lossy().to_string();
+            Some((directory_name, report_path))
+        })
+        .collect::<Vec<_>>();
+
+    candidates.sort_by(|left, right| left.0.cmp(&right.0));
+    candidates.pop().map(|(_, path)| path)
+}
+
+fn build_summary_from_report(report: ScenarioReport, duration_ms: u128) -> MatrixScenarioSummary {
+    MatrixScenarioSummary {
+        scenario_id: report.scenario_id,
+        pass: report.pass,
+        exit_code: report.exit_code,
+        artifact_dir: Some(report.artifact_dir),
+        failure_reason: report.failure_reason,
+        duration_ms,
+    }
+}

--- a/utils/transport-smoke-suite/src/claims.rs
+++ b/utils/transport-smoke-suite/src/claims.rs
@@ -1,0 +1,935 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+use crate::env;
+use anyhow::{anyhow, Context, Result};
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+pub const DEFAULT_CLAIMS_DIRECTORY: &str = "utils/transport-smoke-suite/claims";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ClaimsPathKind {
+    File,
+    Directory,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ClaimKind {
+    MustMatch,
+    MustNotMatch,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ClaimCategory {
+    EndpointCommunication,
+    StreamerEgress,
+    ForbiddenSignature,
+    Readiness,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ThresholdSelector {
+    EndpointCommunication,
+    EgressSendAttempt,
+    EgressSendOk,
+    EgressWorkerCreateOrReuse,
+    Fixed(usize),
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct ClaimTemplate {
+    pub claim_id: &'static str,
+    pub category: ClaimCategory,
+    pub kind: ClaimKind,
+    pub file: &'static str,
+    pub pattern: &'static str,
+    pub threshold: ThresholdSelector,
+}
+
+impl ClaimTemplate {
+    pub const fn must_match(
+        claim_id: &'static str,
+        category: ClaimCategory,
+        file: &'static str,
+        pattern: &'static str,
+        threshold: ThresholdSelector,
+    ) -> Self {
+        Self {
+            claim_id,
+            category,
+            kind: ClaimKind::MustMatch,
+            file,
+            pattern,
+            threshold,
+        }
+    }
+
+    pub const fn must_not_match(
+        claim_id: &'static str,
+        category: ClaimCategory,
+        file: &'static str,
+        pattern: &'static str,
+    ) -> Self {
+        Self {
+            claim_id,
+            category,
+            kind: ClaimKind::MustNotMatch,
+            file,
+            pattern,
+            threshold: ThresholdSelector::Fixed(0),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct Thresholds {
+    pub endpoint_communication_min_count: usize,
+    pub egress_send_attempt_min_count: usize,
+    pub egress_send_ok_min_count: usize,
+    pub egress_worker_create_or_reuse_min_count: usize,
+}
+
+impl Default for Thresholds {
+    fn default() -> Self {
+        Self {
+            endpoint_communication_min_count: env::DEFAULT_ENDPOINT_CLAIM_MIN_COUNT,
+            egress_send_attempt_min_count: env::DEFAULT_EGRESS_SEND_ATTEMPT_MIN_COUNT,
+            egress_send_ok_min_count: env::DEFAULT_EGRESS_SEND_OK_MIN_COUNT,
+            egress_worker_create_or_reuse_min_count: env::DEFAULT_EGRESS_WORKER_MIN_COUNT,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ClaimSpec {
+    pub claim_id: String,
+    pub category: ClaimCategory,
+    pub kind: ClaimKind,
+    pub file: String,
+    pub pattern: String,
+    pub min_count: usize,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ClaimOutcome {
+    pub claim_id: String,
+    pub category: ClaimCategory,
+    pub kind: ClaimKind,
+    pub file: String,
+    pub pattern: String,
+    pub min_count: usize,
+    pub observed_count: usize,
+    pub pass: bool,
+    pub first_match: Option<String>,
+    pub error: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+pub struct LoadedClaims {
+    pub source_path: PathBuf,
+    pub schema_version: String,
+    pub claims: Vec<ClaimSpec>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct ClaimsFile {
+    schema_version: String,
+    scenario_id: String,
+    claims: Vec<ClaimsFileEntry>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct ClaimsFileEntry {
+    claim_id: String,
+    category: ClaimCategory,
+    kind: ClaimKind,
+    file: String,
+    pattern: String,
+    #[serde(default)]
+    threshold: Option<ThresholdValue>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(untagged)]
+enum ThresholdValue {
+    Selector(ThresholdSelectorKey),
+    Fixed(usize),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum ThresholdSelectorKey {
+    EndpointCommunication,
+    EgressSendAttempt,
+    EgressSendOk,
+    EgressWorkerCreateOrReuse,
+}
+
+pub fn materialize_claims(
+    claim_templates: &[ClaimTemplate],
+    thresholds: Thresholds,
+) -> Vec<ClaimSpec> {
+    claim_templates
+        .iter()
+        .map(|claim_template| ClaimSpec {
+            claim_id: claim_template.claim_id.to_string(),
+            category: claim_template.category,
+            kind: claim_template.kind,
+            file: claim_template.file.to_string(),
+            pattern: claim_template.pattern.to_string(),
+            min_count: resolve_threshold(claim_template.threshold, thresholds),
+        })
+        .collect()
+}
+
+fn resolve_threshold(selector: ThresholdSelector, thresholds: Thresholds) -> usize {
+    match selector {
+        ThresholdSelector::EndpointCommunication => thresholds.endpoint_communication_min_count,
+        ThresholdSelector::EgressSendAttempt => thresholds.egress_send_attempt_min_count,
+        ThresholdSelector::EgressSendOk => thresholds.egress_send_ok_min_count,
+        ThresholdSelector::EgressWorkerCreateOrReuse => {
+            thresholds.egress_worker_create_or_reuse_min_count
+        }
+        ThresholdSelector::Fixed(value) => value,
+    }
+}
+
+pub fn default_claims_file_path(repo_root: &Path, scenario_id: &str) -> PathBuf {
+    repo_root
+        .join(DEFAULT_CLAIMS_DIRECTORY)
+        .join(format!("{scenario_id}.json"))
+}
+
+pub fn claims_override_kind(repo_root: &Path, claims_path: &Path) -> Result<ClaimsPathKind> {
+    let candidate = resolve_override_path(repo_root, claims_path);
+    let metadata = fs::metadata(&candidate).with_context(|| {
+        format!(
+            "claims path does not exist or is not accessible: {}",
+            candidate.display()
+        )
+    })?;
+
+    if metadata.is_dir() {
+        Ok(ClaimsPathKind::Directory)
+    } else if metadata.is_file() {
+        Ok(ClaimsPathKind::File)
+    } else {
+        Err(anyhow!(
+            "claims path must be a file or directory: {}",
+            candidate.display()
+        ))
+    }
+}
+
+pub fn resolve_claims_file_path(
+    repo_root: &Path,
+    scenario_id: &str,
+    claims_path_override: Option<&Path>,
+) -> Result<PathBuf> {
+    let candidate = match claims_path_override {
+        None => default_claims_file_path(repo_root, scenario_id),
+        Some(claims_path_override) => {
+            let claims_path_override = resolve_override_path(repo_root, claims_path_override);
+            let metadata = fs::metadata(&claims_path_override).with_context(|| {
+                format!(
+                    "claims path does not exist or is not accessible: {}",
+                    claims_path_override.display()
+                )
+            })?;
+
+            if metadata.is_dir() {
+                claims_path_override.join(format!("{scenario_id}.json"))
+            } else if metadata.is_file() {
+                claims_path_override
+            } else {
+                return Err(anyhow!(
+                    "claims path must be a file or directory: {}",
+                    claims_path_override.display()
+                ));
+            }
+        }
+    };
+
+    let metadata = fs::metadata(&candidate).with_context(|| {
+        format!(
+            "resolved claims file does not exist or is not accessible: {}",
+            candidate.display()
+        )
+    })?;
+
+    if !metadata.is_file() {
+        return Err(anyhow!(
+            "resolved claims path is not a file: {}",
+            candidate.display()
+        ));
+    }
+
+    Ok(candidate)
+}
+
+pub fn load_claims_for_scenario(
+    repo_root: &Path,
+    scenario_id: &str,
+    claims_path_override: Option<&Path>,
+    thresholds: Thresholds,
+) -> Result<LoadedClaims> {
+    let source_path = resolve_claims_file_path(repo_root, scenario_id, claims_path_override)?;
+    let payload = fs::read_to_string(&source_path)
+        .with_context(|| format!("unable to read claims file {}", source_path.display()))?;
+
+    let claims_file: ClaimsFile = serde_json::from_str(&payload)
+        .with_context(|| format!("unable to parse claims file {}", source_path.display()))?;
+
+    if claims_file.schema_version.trim().is_empty() {
+        return Err(anyhow!(
+            "claims file {} has an empty schema_version",
+            source_path.display()
+        ));
+    }
+
+    if claims_file.scenario_id != scenario_id {
+        return Err(anyhow!(
+            "claims file {} targets scenario '{}' but requested scenario is '{}'",
+            source_path.display(),
+            claims_file.scenario_id,
+            scenario_id
+        ));
+    }
+
+    if claims_file.claims.is_empty() {
+        return Err(anyhow!(
+            "claims file {} contains no claims",
+            source_path.display()
+        ));
+    }
+
+    let claims = materialize_claim_specs_from_file(&claims_file, thresholds, &source_path)?;
+
+    Ok(LoadedClaims {
+        source_path,
+        schema_version: claims_file.schema_version,
+        claims,
+    })
+}
+
+fn materialize_claim_specs_from_file(
+    claims_file: &ClaimsFile,
+    thresholds: Thresholds,
+    source_path: &Path,
+) -> Result<Vec<ClaimSpec>> {
+    let mut claim_ids = HashSet::new();
+    let mut claims = Vec::with_capacity(claims_file.claims.len());
+
+    for claim in &claims_file.claims {
+        validate_claim_entry(claim, source_path)?;
+
+        if !claim_ids.insert(claim.claim_id.clone()) {
+            return Err(anyhow!(
+                "claims file {} contains duplicate claim_id '{}'",
+                source_path.display(),
+                claim.claim_id
+            ));
+        }
+
+        let min_count = resolve_file_claim_threshold(claim, thresholds, source_path)?;
+        claims.push(ClaimSpec {
+            claim_id: claim.claim_id.clone(),
+            category: claim.category,
+            kind: claim.kind,
+            file: claim.file.clone(),
+            pattern: claim.pattern.clone(),
+            min_count,
+        });
+    }
+
+    Ok(claims)
+}
+
+fn validate_claim_entry(claim: &ClaimsFileEntry, source_path: &Path) -> Result<()> {
+    if claim.claim_id.trim().is_empty() {
+        return Err(anyhow!(
+            "claims file {} has a claim with empty claim_id",
+            source_path.display()
+        ));
+    }
+    if claim.file.trim().is_empty() {
+        return Err(anyhow!(
+            "claim '{}' in {} has empty file",
+            claim.claim_id,
+            source_path.display()
+        ));
+    }
+    if claim.pattern.trim().is_empty() {
+        return Err(anyhow!(
+            "claim '{}' in {} has empty pattern",
+            claim.claim_id,
+            source_path.display()
+        ));
+    }
+
+    Regex::new(&claim.pattern).with_context(|| {
+        format!(
+            "claim '{}' in {} has invalid regex '{}'",
+            claim.claim_id,
+            source_path.display(),
+            claim.pattern
+        )
+    })?;
+
+    Ok(())
+}
+
+fn resolve_file_claim_threshold(
+    claim: &ClaimsFileEntry,
+    thresholds: Thresholds,
+    source_path: &Path,
+) -> Result<usize> {
+    match claim.kind {
+        ClaimKind::MustMatch => match claim.threshold {
+            Some(ThresholdValue::Selector(selector_key)) => {
+                Ok(resolve_selector_key(selector_key, thresholds))
+            }
+            Some(ThresholdValue::Fixed(value)) => Ok(value),
+            None => Err(anyhow!(
+                "claim '{}' in {} is must_match and requires a threshold",
+                claim.claim_id,
+                source_path.display()
+            )),
+        },
+        ClaimKind::MustNotMatch => {
+            if claim.threshold.is_some() {
+                return Err(anyhow!(
+                    "claim '{}' in {} is must_not_match and must not define a threshold",
+                    claim.claim_id,
+                    source_path.display()
+                ));
+            }
+
+            Ok(0)
+        }
+    }
+}
+
+fn resolve_selector_key(selector_key: ThresholdSelectorKey, thresholds: Thresholds) -> usize {
+    match selector_key {
+        ThresholdSelectorKey::EndpointCommunication => thresholds.endpoint_communication_min_count,
+        ThresholdSelectorKey::EgressSendAttempt => thresholds.egress_send_attempt_min_count,
+        ThresholdSelectorKey::EgressSendOk => thresholds.egress_send_ok_min_count,
+        ThresholdSelectorKey::EgressWorkerCreateOrReuse => {
+            thresholds.egress_worker_create_or_reuse_min_count
+        }
+    }
+}
+
+fn resolve_override_path(repo_root: &Path, claims_path: &Path) -> PathBuf {
+    if claims_path.is_absolute() {
+        claims_path.to_path_buf()
+    } else {
+        repo_root.join(claims_path)
+    }
+}
+
+pub fn evaluate_claims(artifacts_dir: &Path, claims: &[ClaimSpec]) -> Vec<ClaimOutcome> {
+    claims
+        .iter()
+        .map(|claim| evaluate_claim(artifacts_dir, claim))
+        .collect()
+}
+
+fn evaluate_claim(artifacts_dir: &Path, claim: &ClaimSpec) -> ClaimOutcome {
+    let file_path = artifacts_dir.join(&claim.file);
+    let file_content = match fs::read_to_string(&file_path) {
+        Ok(file_content) => file_content,
+        Err(error) => {
+            return ClaimOutcome {
+                claim_id: claim.claim_id.clone(),
+                category: claim.category,
+                kind: claim.kind,
+                file: claim.file.clone(),
+                pattern: claim.pattern.clone(),
+                min_count: claim.min_count,
+                observed_count: 0,
+                pass: false,
+                first_match: None,
+                error: Some(format!("unable to read {}: {error}", file_path.display())),
+            }
+        }
+    };
+
+    let regex = match Regex::new(&claim.pattern) {
+        Ok(regex) => regex,
+        Err(error) => {
+            return ClaimOutcome {
+                claim_id: claim.claim_id.clone(),
+                category: claim.category,
+                kind: claim.kind,
+                file: claim.file.clone(),
+                pattern: claim.pattern.clone(),
+                min_count: claim.min_count,
+                observed_count: 0,
+                pass: false,
+                first_match: None,
+                error: Some(format!("invalid regex '{}': {error}", claim.pattern)),
+            }
+        }
+    };
+
+    let mut match_iter = regex.find_iter(&file_content);
+    let first_match = match_iter
+        .next()
+        .map(|first_match| first_match.as_str().to_string());
+    let observed_count = first_match
+        .as_ref()
+        .map(|_| 1 + match_iter.count())
+        .unwrap_or(0);
+
+    let pass = match claim.kind {
+        ClaimKind::MustMatch => observed_count >= claim.min_count,
+        ClaimKind::MustNotMatch => observed_count == 0,
+    };
+
+    ClaimOutcome {
+        claim_id: claim.claim_id.clone(),
+        category: claim.category,
+        kind: claim.kind,
+        file: claim.file.clone(),
+        pattern: claim.pattern.clone(),
+        min_count: claim.min_count,
+        observed_count,
+        pass,
+        first_match,
+        error: None,
+    }
+}
+
+pub fn split_claim_outcomes(
+    outcomes: Vec<ClaimOutcome>,
+) -> (Vec<ClaimOutcome>, Vec<ClaimOutcome>, Option<String>) {
+    let mut must_outcomes = Vec::new();
+    let mut forbidden_outcomes = Vec::new();
+    let mut first_failure_reason = None;
+
+    for outcome in outcomes {
+        if !outcome.pass && first_failure_reason.is_none() {
+            first_failure_reason = Some(format!(
+                "claim '{}' failed (file='{}', observed={}, min={}, pattern='{}')",
+                outcome.claim_id,
+                outcome.file,
+                outcome.observed_count,
+                outcome.min_count,
+                outcome.pattern
+            ));
+        }
+
+        if outcome.kind == ClaimKind::MustNotMatch {
+            forbidden_outcomes.push(outcome);
+        } else {
+            must_outcomes.push(outcome);
+        }
+    }
+
+    (must_outcomes, forbidden_outcomes, first_failure_reason)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        claims_override_kind, default_claims_file_path, evaluate_claims, load_claims_for_scenario,
+        materialize_claims, resolve_claims_file_path, split_claim_outcomes, ClaimCategory,
+        ClaimKind, ClaimTemplate, ClaimsPathKind, ThresholdSelector, Thresholds,
+        DEFAULT_CLAIMS_DIRECTORY,
+    };
+    use std::fs;
+    use std::path::Path;
+    use tempfile::TempDir;
+
+    #[test]
+    fn must_match_counts_non_overlapping_regex_matches() {
+        let temp_dir = TempDir::new().expect("create temp dir");
+        fs::write(
+            temp_dir.path().join("streamer.log"),
+            "event=egress_send_attempt event=egress_send_attempt\n",
+        )
+        .expect("write fixture");
+
+        let claims = materialize_claims(
+            &[ClaimTemplate::must_match(
+                "attempt",
+                ClaimCategory::StreamerEgress,
+                "streamer.log",
+                "event=egress_send_attempt",
+                ThresholdSelector::Fixed(2),
+            )],
+            Thresholds::default(),
+        );
+
+        let outcomes = evaluate_claims(temp_dir.path(), &claims);
+        assert_eq!(outcomes[0].observed_count, 2);
+        assert!(outcomes[0].pass);
+    }
+
+    #[test]
+    fn must_not_match_fails_when_forbidden_pattern_exists() {
+        let temp_dir = TempDir::new().expect("create temp dir");
+        fs::write(
+            temp_dir.path().join("streamer.log"),
+            "thread panicked at boom\n",
+        )
+        .expect("write fixture");
+
+        let claims = materialize_claims(
+            &[ClaimTemplate::must_not_match(
+                "no_panic",
+                ClaimCategory::ForbiddenSignature,
+                "streamer.log",
+                "panicked at",
+            )],
+            Thresholds::default(),
+        );
+
+        let outcomes = evaluate_claims(temp_dir.path(), &claims);
+        assert_eq!(outcomes[0].kind, ClaimKind::MustNotMatch);
+        assert_eq!(outcomes[0].observed_count, 1);
+        assert!(!outcomes[0].pass);
+    }
+
+    #[test]
+    fn missing_file_is_hard_claim_failure() {
+        let temp_dir = TempDir::new().expect("create temp dir");
+        let claims = materialize_claims(
+            &[ClaimTemplate::must_match(
+                "missing",
+                ClaimCategory::EndpointCommunication,
+                "service.log",
+                "Sending Response message",
+                ThresholdSelector::EndpointCommunication,
+            )],
+            Thresholds::default(),
+        );
+
+        let outcomes = evaluate_claims(temp_dir.path(), &claims);
+        assert!(!outcomes[0].pass);
+        assert!(outcomes[0].error.is_some());
+    }
+
+    #[test]
+    fn malformed_regex_is_hard_claim_failure() {
+        let temp_dir = TempDir::new().expect("create temp dir");
+        fs::write(temp_dir.path().join("client.log"), "any content\n").expect("write fixture");
+
+        let claims = materialize_claims(
+            &[ClaimTemplate::must_match(
+                "bad_regex",
+                ClaimCategory::EndpointCommunication,
+                "client.log",
+                "(unclosed",
+                ThresholdSelector::Fixed(1),
+            )],
+            Thresholds::default(),
+        );
+
+        let outcomes = evaluate_claims(temp_dir.path(), &claims);
+        assert!(!outcomes[0].pass);
+        assert!(outcomes[0].error.is_some());
+    }
+
+    #[test]
+    fn split_claim_outcomes_separates_forbidden_claims() {
+        let temp_dir = TempDir::new().expect("create temp dir");
+        fs::write(
+            temp_dir.path().join("streamer.log"),
+            "event=egress_send_ok\n",
+        )
+        .expect("write fixture");
+
+        let claims = materialize_claims(
+            &[
+                ClaimTemplate::must_match(
+                    "send_ok",
+                    ClaimCategory::StreamerEgress,
+                    "streamer.log",
+                    "event=egress_send_ok",
+                    ThresholdSelector::Fixed(1),
+                ),
+                ClaimTemplate::must_not_match(
+                    "no_panic",
+                    ClaimCategory::ForbiddenSignature,
+                    "streamer.log",
+                    "panicked at",
+                ),
+            ],
+            Thresholds::default(),
+        );
+
+        let outcomes = evaluate_claims(temp_dir.path(), &claims);
+        let (must_outcomes, forbidden_outcomes, first_failure) = split_claim_outcomes(outcomes);
+
+        assert_eq!(must_outcomes.len(), 1);
+        assert_eq!(forbidden_outcomes.len(), 1);
+        assert!(first_failure.is_none());
+    }
+
+    #[test]
+    fn resolve_claims_file_path_uses_default_directory() {
+        let temp_dir = TempDir::new().expect("create temp dir");
+        let repo_root = temp_dir.path();
+        let scenario_id = "smoke-example";
+
+        write_claims_file(
+            repo_root,
+            scenario_id,
+            valid_claims_payload(scenario_id, "endpoint_communication"),
+        );
+
+        let resolved = resolve_claims_file_path(repo_root, scenario_id, None)
+            .expect("resolve claims file path");
+        assert_eq!(resolved, default_claims_file_path(repo_root, scenario_id));
+    }
+
+    #[test]
+    fn claims_override_kind_detects_file_and_directory() {
+        let temp_dir = TempDir::new().expect("create temp dir");
+        let repo_root = temp_dir.path();
+        let scenario_id = "smoke-example";
+
+        let claims_file = write_claims_file(
+            repo_root,
+            scenario_id,
+            valid_claims_payload(scenario_id, "endpoint_communication"),
+        );
+
+        let claims_dir = claims_file.parent().expect("claims dir");
+        assert_eq!(
+            claims_override_kind(repo_root, claims_dir).expect("directory kind"),
+            ClaimsPathKind::Directory
+        );
+        assert_eq!(
+            claims_override_kind(repo_root, &claims_file).expect("file kind"),
+            ClaimsPathKind::File
+        );
+    }
+
+    #[test]
+    fn load_claims_for_scenario_resolves_selector_thresholds() {
+        let temp_dir = TempDir::new().expect("create temp dir");
+        let repo_root = temp_dir.path();
+        let scenario_id = "smoke-example";
+
+        write_claims_file(
+            repo_root,
+            scenario_id,
+            valid_claims_payload(scenario_id, "egress_send_ok"),
+        );
+
+        let loaded = load_claims_for_scenario(
+            repo_root,
+            scenario_id,
+            None,
+            Thresholds {
+                endpoint_communication_min_count: 4,
+                egress_send_attempt_min_count: 2,
+                egress_send_ok_min_count: 7,
+                egress_worker_create_or_reuse_min_count: 1,
+            },
+        )
+        .expect("load claims");
+
+        assert_eq!(loaded.schema_version, "1.0");
+        assert_eq!(loaded.claims.len(), 2);
+        assert_eq!(loaded.claims[0].min_count, 7);
+        assert_eq!(loaded.claims[1].min_count, 0);
+    }
+
+    #[test]
+    fn load_claims_for_scenario_supports_directory_override() {
+        let temp_dir = TempDir::new().expect("create temp dir");
+        let repo_root = temp_dir.path();
+        let scenario_id = "smoke-example";
+
+        let claims_dir = repo_root.join("custom-claims");
+        let claims_file = claims_dir.join(format!("{scenario_id}.json"));
+        write_claims_file_at(
+            &claims_file,
+            valid_claims_payload(scenario_id, "endpoint_communication"),
+        );
+
+        let loaded = load_claims_for_scenario(
+            repo_root,
+            scenario_id,
+            Some(claims_dir.as_path()),
+            Thresholds::default(),
+        )
+        .expect("load claims from directory override");
+
+        assert_eq!(loaded.source_path, claims_file);
+        assert_eq!(loaded.claims.len(), 2);
+    }
+
+    #[test]
+    fn load_claims_for_scenario_supports_file_override() {
+        let temp_dir = TempDir::new().expect("create temp dir");
+        let repo_root = temp_dir.path();
+        let scenario_id = "smoke-example";
+
+        let claims_file = repo_root.join("claims-one-off.json");
+        write_claims_file_at(
+            &claims_file,
+            valid_claims_payload(scenario_id, "endpoint_communication"),
+        );
+
+        let loaded = load_claims_for_scenario(
+            repo_root,
+            scenario_id,
+            Some(claims_file.as_path()),
+            Thresholds::default(),
+        )
+        .expect("load claims from file override");
+
+        assert_eq!(loaded.source_path, claims_file);
+        assert_eq!(loaded.claims.len(), 2);
+    }
+
+    #[test]
+    fn load_claims_for_scenario_rejects_missing_file() {
+        let temp_dir = TempDir::new().expect("create temp dir");
+        let repo_root = temp_dir.path();
+
+        let error =
+            load_claims_for_scenario(repo_root, "smoke-missing", None, Thresholds::default())
+                .expect_err("expected missing file failure");
+        assert!(error
+            .to_string()
+            .contains("resolved claims file does not exist or is not accessible"));
+    }
+
+    #[test]
+    fn load_claims_for_scenario_rejects_malformed_json() {
+        let temp_dir = TempDir::new().expect("create temp dir");
+        let repo_root = temp_dir.path();
+        let scenario_id = "smoke-example";
+
+        write_claims_file(
+            repo_root,
+            scenario_id,
+            "{\n  \"schema_version\": \"1.0\",\n  \"scenario_id\": \"smoke-example\",\n  \"claims\": [\n"
+                .to_string(),
+        );
+
+        let error = load_claims_for_scenario(repo_root, scenario_id, None, Thresholds::default())
+            .expect_err("expected malformed json failure");
+        assert!(error.to_string().contains("unable to parse claims file"));
+    }
+
+    #[test]
+    fn load_claims_for_scenario_rejects_scenario_id_mismatch() {
+        let temp_dir = TempDir::new().expect("create temp dir");
+        let repo_root = temp_dir.path();
+
+        write_claims_file(
+            repo_root,
+            "smoke-a",
+            valid_claims_payload("smoke-b", "endpoint_communication"),
+        );
+
+        let error = load_claims_for_scenario(repo_root, "smoke-a", None, Thresholds::default())
+            .expect_err("expected scenario id mismatch");
+        assert!(error.to_string().contains("targets scenario 'smoke-b'"));
+    }
+
+    #[test]
+    fn load_claims_for_scenario_rejects_duplicate_claim_ids() {
+        let temp_dir = TempDir::new().expect("create temp dir");
+        let repo_root = temp_dir.path();
+        let scenario_id = "smoke-example";
+
+        write_claims_file(
+            repo_root,
+            scenario_id,
+            format!(
+                "{{\n  \"schema_version\": \"1.0\",\n  \"scenario_id\": \"{scenario_id}\",\n  \"claims\": [\n    {{\n      \"claim_id\": \"dup\",\n      \"category\": \"endpoint_communication\",\n      \"kind\": \"must_match\",\n      \"file\": \"client.log\",\n      \"pattern\": \"ok\",\n      \"threshold\": \"endpoint_communication\"\n    }},\n    {{\n      \"claim_id\": \"dup\",\n      \"category\": \"forbidden_signature\",\n      \"kind\": \"must_not_match\",\n      \"file\": \"streamer.log\",\n      \"pattern\": \"panicked at\"\n    }}\n  ]\n}}"
+            ),
+        );
+
+        let error = load_claims_for_scenario(repo_root, scenario_id, None, Thresholds::default())
+            .expect_err("expected duplicate claim id failure");
+        assert!(error.to_string().contains("duplicate claim_id"));
+    }
+
+    #[test]
+    fn load_claims_for_scenario_rejects_threshold_on_must_not_match() {
+        let temp_dir = TempDir::new().expect("create temp dir");
+        let repo_root = temp_dir.path();
+        let scenario_id = "smoke-example";
+
+        write_claims_file(
+            repo_root,
+            scenario_id,
+            format!(
+                "{{\n  \"schema_version\": \"1.0\",\n  \"scenario_id\": \"{scenario_id}\",\n  \"claims\": [\n    {{\n      \"claim_id\": \"no_panic\",\n      \"category\": \"forbidden_signature\",\n      \"kind\": \"must_not_match\",\n      \"file\": \"streamer.log\",\n      \"pattern\": \"panicked at\",\n      \"threshold\": 1\n    }}\n  ]\n}}"
+            ),
+        );
+
+        let error = load_claims_for_scenario(repo_root, scenario_id, None, Thresholds::default())
+            .expect_err("expected threshold validation failure");
+        assert!(error
+            .to_string()
+            .contains("must_not_match and must not define a threshold"));
+    }
+
+    #[test]
+    fn load_claims_for_scenario_rejects_invalid_threshold_descriptor() {
+        let temp_dir = TempDir::new().expect("create temp dir");
+        let repo_root = temp_dir.path();
+        let scenario_id = "smoke-example";
+
+        write_claims_file(
+            repo_root,
+            scenario_id,
+            valid_claims_payload(scenario_id, "not_a_threshold_selector"),
+        );
+
+        let error = load_claims_for_scenario(repo_root, scenario_id, None, Thresholds::default())
+            .expect_err("expected invalid threshold descriptor failure");
+        assert!(error.to_string().contains("unable to parse claims file"));
+    }
+
+    fn write_claims_file(
+        repo_root: &Path,
+        scenario_id: &str,
+        payload: String,
+    ) -> std::path::PathBuf {
+        let claims_path = repo_root
+            .join(DEFAULT_CLAIMS_DIRECTORY)
+            .join(format!("{scenario_id}.json"));
+        write_claims_file_at(&claims_path, payload);
+        claims_path
+    }
+
+    fn write_claims_file_at(claims_path: &Path, payload: String) {
+        fs::create_dir_all(claims_path.parent().expect("claims parent"))
+            .expect("create claims dir");
+        fs::write(claims_path, payload).expect("write claims file");
+    }
+
+    fn valid_claims_payload(scenario_id: &str, selector: &str) -> String {
+        format!(
+            "{{\n  \"schema_version\": \"1.0\",\n  \"scenario_id\": \"{scenario_id}\",\n  \"claims\": [\n    {{\n      \"claim_id\": \"endpoint\",\n      \"category\": \"endpoint_communication\",\n      \"kind\": \"must_match\",\n      \"file\": \"client.log\",\n      \"pattern\": \"ok\",\n      \"threshold\": \"{selector}\"\n    }},\n    {{\n      \"claim_id\": \"no_panic\",\n      \"category\": \"forbidden_signature\",\n      \"kind\": \"must_not_match\",\n      \"file\": \"streamer.log\",\n      \"pattern\": \"panicked at\"\n    }}\n  ]\n}}"
+        )
+    }
+}

--- a/utils/transport-smoke-suite/src/env.rs
+++ b/utils/transport-smoke-suite/src/env.rs
@@ -1,0 +1,169 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+use anyhow::{anyhow, Context, Result};
+use chrono::Utc;
+use std::fs;
+use std::path::{Path, PathBuf};
+use tokio::process::Command;
+
+pub const DEFAULT_SEND_COUNT: u64 = 12;
+pub const DEFAULT_SEND_INTERVAL_MS: u64 = 1000;
+
+pub const DEFAULT_ENDPOINT_CLAIM_MIN_COUNT: usize = 4;
+pub const DEFAULT_EGRESS_SEND_ATTEMPT_MIN_COUNT: usize = 2;
+pub const DEFAULT_EGRESS_SEND_OK_MIN_COUNT: usize = 2;
+pub const DEFAULT_EGRESS_WORKER_MIN_COUNT: usize = 1;
+
+pub const BROKER_READY_TIMEOUT_SECS: u64 = 30;
+pub const STREAMER_READY_TIMEOUT_SECS: u64 = 60;
+pub const PASSIVE_READY_TIMEOUT_SECS: u64 = 30;
+pub const MQTT_HARD_TIMEOUT_SECS: u64 = 120;
+pub const SOMEIP_HARD_TIMEOUT_SECS: u64 = 180;
+pub const SIGINT_GRACE_SECS: u64 = 5;
+pub const SIGTERM_GRACE_SECS: u64 = 5;
+pub const LOG_POLL_INTERVAL_MS: u64 = 100;
+
+pub const READY_STREAMER_INITIALIZED: &str = "READY streamer_initialized";
+pub const READY_LISTENER_REGISTERED: &str = "READY listener_registered";
+
+pub fn repo_root() -> Result<PathBuf> {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    manifest_dir
+        .ancestors()
+        .nth(2)
+        .map(Path::to_path_buf)
+        .ok_or_else(|| {
+            anyhow!(
+                "unable to resolve workspace root from {}",
+                manifest_dir.display()
+            )
+        })
+}
+
+pub fn resolve_artifacts_root(repo_root: &Path, artifacts_root: Option<PathBuf>) -> PathBuf {
+    artifacts_root.unwrap_or_else(|| repo_root.join("target").join("transport-smoke"))
+}
+
+pub fn resolve_expected_branch(expected_branch: Option<String>) -> Option<String> {
+    expected_branch.or_else(|| {
+        std::env::var("SMOKE_EXPECTED_BRANCH")
+            .ok()
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty())
+    })
+}
+
+pub fn scenario_timestamp() -> String {
+    Utc::now().format("%Y%m%dT%H%M%SZ").to_string()
+}
+
+pub async fn enforce_expected_branch(
+    repo_root: &Path,
+    expected_branch: Option<&str>,
+) -> Result<()> {
+    let Some(expected_branch) = expected_branch else {
+        return Ok(());
+    };
+
+    let output = Command::new("git")
+        .arg("rev-parse")
+        .arg("--abbrev-ref")
+        .arg("HEAD")
+        .current_dir(repo_root)
+        .output()
+        .await
+        .context("failed to query current git branch")?;
+
+    if !output.status.success() {
+        return Err(anyhow!(
+            "git branch query failed with status {}",
+            output.status
+        ));
+    }
+
+    let current_branch = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if current_branch != expected_branch {
+        return Err(anyhow!(
+            "branch guard mismatch: expected '{}', found '{}'. Pass --expected-branch or unset SMOKE_EXPECTED_BRANCH to control this guard",
+            expected_branch,
+            current_branch
+        ));
+    }
+
+    Ok(())
+}
+
+pub fn ensure_paths_exist(repo_root: &Path, required_paths: &[&str]) -> Result<()> {
+    for relative_path in required_paths {
+        let candidate = repo_root.join(relative_path);
+        if !candidate.exists() {
+            return Err(anyhow!(
+                "required path does not exist: {}",
+                candidate.display()
+            ));
+        }
+    }
+    Ok(())
+}
+
+pub fn detect_vsomeip_runtime_lib(repo_root: &Path) -> Result<PathBuf> {
+    let build_dir = repo_root.join("target").join("debug").join("build");
+    if !build_dir.exists() {
+        return Err(anyhow!(
+            "missing build output directory for vsomeip lookup: {}",
+            build_dir.display()
+        ));
+    }
+
+    let mut candidates = Vec::new();
+    for entry in fs::read_dir(&build_dir)
+        .with_context(|| format!("unable to read build directory {}", build_dir.display()))?
+    {
+        let entry = entry?;
+        let file_name = entry.file_name();
+        let file_name = file_name.to_string_lossy();
+        if !file_name.starts_with("vsomeip-sys-") {
+            continue;
+        }
+
+        let candidate = entry
+            .path()
+            .join("out")
+            .join("vsomeip")
+            .join("vsomeip-install")
+            .join("lib");
+
+        if candidate.exists() {
+            let modified = fs::metadata(&candidate)
+                .and_then(|metadata| metadata.modified())
+                .with_context(|| {
+                    format!(
+                        "unable to inspect modified time for {}",
+                        candidate.display()
+                    )
+                })?;
+            candidates.push((modified, candidate));
+        }
+    }
+
+    candidates.sort_by_key(|(modified, _)| *modified);
+    candidates
+        .pop()
+        .map(|(_, path)| path)
+        .ok_or_else(|| {
+            anyhow!(
+                "unable to locate bundled vsomeip runtime under target/debug/build/vsomeip-sys-*/out/vsomeip/vsomeip-install/lib"
+            )
+        })
+}

--- a/utils/transport-smoke-suite/src/lib.rs
+++ b/utils/transport-smoke-suite/src/lib.rs
@@ -1,0 +1,19 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+pub mod claims;
+pub mod env;
+pub mod logs;
+pub mod process;
+pub mod report;
+pub mod scenario;

--- a/utils/transport-smoke-suite/src/logs.rs
+++ b/utils/transport-smoke-suite/src/logs.rs
@@ -1,0 +1,82 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+use anyhow::{anyhow, Context, Result};
+use std::collections::VecDeque;
+use std::fs;
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+pub async fn wait_for_exact_marker(
+    log_path: &Path,
+    marker: &str,
+    timeout: Duration,
+    poll_interval: Duration,
+) -> Result<()> {
+    let deadline = Instant::now() + timeout;
+
+    loop {
+        if has_exact_marker(log_path, marker)? {
+            return Ok(());
+        }
+
+        if Instant::now() >= deadline {
+            let tail = tail_lines(log_path, 25).unwrap_or_default();
+            return Err(anyhow!(
+                "timed out waiting for marker '{}' in {} (tail: {})",
+                marker,
+                log_path.display(),
+                tail.join(" | ")
+            ));
+        }
+
+        tokio::time::sleep(poll_interval).await;
+    }
+}
+
+pub fn count_exact_marker(log_path: &Path, marker: &str) -> Result<usize> {
+    if !log_path.exists() {
+        return Ok(0);
+    }
+
+    let content = fs::read_to_string(log_path)
+        .with_context(|| format!("unable to read log file {}", log_path.display()))?;
+
+    Ok(content
+        .lines()
+        .filter(|line| line.trim_end_matches(['\r', '\n']) == marker)
+        .count())
+}
+
+pub fn has_exact_marker(log_path: &Path, marker: &str) -> Result<bool> {
+    Ok(count_exact_marker(log_path, marker)? > 0)
+}
+
+pub fn tail_lines(log_path: &Path, max_lines: usize) -> Result<Vec<String>> {
+    if !log_path.exists() {
+        return Ok(Vec::new());
+    }
+
+    let content = fs::read_to_string(log_path)
+        .with_context(|| format!("unable to read log file {}", log_path.display()))?;
+
+    let mut deque = VecDeque::with_capacity(max_lines);
+    for line in content.lines() {
+        if deque.len() == max_lines {
+            deque.pop_front();
+        }
+        deque.push_back(line.to_string());
+    }
+
+    Ok(deque.into_iter().collect())
+}

--- a/utils/transport-smoke-suite/src/process.rs
+++ b/utils/transport-smoke-suite/src/process.rs
@@ -1,0 +1,280 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+use anyhow::{anyhow, Context, Result};
+use chrono::{DateTime, Utc};
+use std::fs::OpenOptions;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::time::Duration;
+use tokio::process::{Child, Command};
+
+#[derive(Debug)]
+pub struct CommandOutcome {
+    pub command: String,
+    pub status_code: Option<i32>,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct ProcessSpec {
+    pub name: String,
+    pub workdir: PathBuf,
+    pub executable: PathBuf,
+    pub args: Vec<String>,
+    pub env: Vec<(String, String)>,
+    pub log_file_name: String,
+}
+
+#[derive(Debug)]
+pub struct ManagedProcess {
+    pub name: String,
+    pub pid: i32,
+    pub process_group_id: i32,
+    pub command_line: String,
+    pub workdir: PathBuf,
+    pub log_path: PathBuf,
+    pub started_at: DateTime<Utc>,
+    pub ended_at: Option<DateTime<Utc>>,
+    pub exit_status_code: Option<i32>,
+    child: Child,
+}
+
+pub async fn run_shell_command(
+    repo_root: &Path,
+    workdir: &Path,
+    command: &str,
+    no_bootstrap: bool,
+) -> Result<CommandOutcome> {
+    let full_command = with_optional_bootstrap(repo_root, command, no_bootstrap);
+    let output = Command::new("bash")
+        .arg("-lc")
+        .arg(&full_command)
+        .current_dir(workdir)
+        .output()
+        .await
+        .with_context(|| format!("failed to execute shell command: {full_command}"))?;
+
+    Ok(CommandOutcome {
+        command: full_command,
+        status_code: output.status.code(),
+        stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+        stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+    })
+}
+
+pub fn shell_escape(value: &str) -> String {
+    let escaped = value.replace('\'', "'\"'\"'");
+    format!("'{escaped}'")
+}
+
+impl ManagedProcess {
+    pub async fn spawn(
+        spec: ProcessSpec,
+        repo_root: &Path,
+        artifacts_dir: &Path,
+        no_bootstrap: bool,
+    ) -> Result<Self> {
+        let log_path = artifacts_dir.join(&spec.log_file_name);
+        let stdout_file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&log_path)
+            .with_context(|| format!("unable to open log file {}", log_path.display()))?;
+        let stderr_file = stdout_file
+            .try_clone()
+            .with_context(|| format!("unable to clone log file {}", log_path.display()))?;
+
+        let exec_command = render_exec_command(&spec.executable, &spec.args);
+        let env_prefix = render_env_prefix(&spec.env);
+        let shell_body = if env_prefix.is_empty() {
+            exec_command
+        } else {
+            format!("{env_prefix} && {exec_command}")
+        };
+        let full_command = with_optional_bootstrap(repo_root, &shell_body, no_bootstrap);
+
+        let mut command = Command::new("bash");
+        command
+            .arg("-lc")
+            .arg(&full_command)
+            .current_dir(&spec.workdir)
+            .stdin(Stdio::null())
+            .stdout(Stdio::from(stdout_file))
+            .stderr(Stdio::from(stderr_file));
+
+        unsafe {
+            command.pre_exec(|| {
+                if libc::setpgid(0, 0) != 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+
+        let child = command.spawn().with_context(|| {
+            format!(
+                "unable to spawn process '{}' with command '{}': in {}",
+                spec.name,
+                full_command,
+                spec.workdir.display()
+            )
+        })?;
+
+        let pid = child
+            .id()
+            .ok_or_else(|| anyhow!("spawned process '{}' has no pid", spec.name))?
+            as i32;
+
+        Ok(Self {
+            name: spec.name,
+            pid,
+            process_group_id: pid,
+            command_line: full_command,
+            workdir: spec.workdir,
+            log_path,
+            started_at: Utc::now(),
+            ended_at: None,
+            exit_status_code: None,
+            child,
+        })
+    }
+
+    pub fn has_exited(&self) -> bool {
+        self.ended_at.is_some()
+    }
+
+    pub async fn refresh_exit_status(&mut self) -> Result<()> {
+        if self.exit_status_code.is_some() {
+            return Ok(());
+        }
+
+        if let Some(status) = self.child.try_wait().with_context(|| {
+            format!(
+                "unable to query process status for '{}'(pid={})",
+                self.name, self.pid
+            )
+        })? {
+            self.exit_status_code = status.code();
+            self.ended_at = Some(Utc::now());
+        }
+
+        Ok(())
+    }
+
+    pub async fn wait_with_timeout(&mut self, timeout: Duration) -> Result<bool> {
+        self.refresh_exit_status().await?;
+        if self.exit_status_code.is_some() {
+            return Ok(true);
+        }
+
+        let wait_result = tokio::time::timeout(timeout, self.child.wait()).await;
+        match wait_result {
+            Ok(wait_outcome) => {
+                let status = wait_outcome.with_context(|| {
+                    format!(
+                        "unable to wait on process '{}'(pid={})",
+                        self.name, self.pid
+                    )
+                })?;
+                self.exit_status_code = status.code();
+                self.ended_at = Some(Utc::now());
+                Ok(true)
+            }
+            Err(_) => Ok(false),
+        }
+    }
+
+    pub async fn terminate_gracefully(
+        &mut self,
+        sigint_grace: Duration,
+        sigterm_grace: Duration,
+    ) -> Result<()> {
+        self.refresh_exit_status().await?;
+        if self.exit_status_code.is_some() {
+            return Ok(());
+        }
+
+        self.signal_process_group(libc::SIGINT)?;
+        if self.wait_with_timeout(sigint_grace).await? {
+            return Ok(());
+        }
+
+        self.signal_process_group(libc::SIGTERM)?;
+        if self.wait_with_timeout(sigterm_grace).await? {
+            return Ok(());
+        }
+
+        self.refresh_exit_status().await?;
+        if self.exit_status_code.is_none() {
+            return Err(anyhow!(
+                "process '{}' (pid={}, pgid={}) did not terminate after SIGINT/SIGTERM grace windows",
+                self.name,
+                self.pid,
+                self.process_group_id
+            ));
+        }
+
+        Ok(())
+    }
+
+    fn signal_process_group(&self, signal: i32) -> Result<()> {
+        let target_pgid = -self.process_group_id;
+        let rc = unsafe { libc::kill(target_pgid, signal) };
+        if rc == 0 {
+            return Ok(());
+        }
+
+        let error = std::io::Error::last_os_error();
+        if error.raw_os_error() == Some(libc::ESRCH) {
+            return Ok(());
+        }
+
+        Err(anyhow!(
+            "unable to send signal {} to process group {}: {}",
+            signal,
+            self.process_group_id,
+            error
+        ))
+    }
+}
+
+fn render_env_prefix(environment: &[(String, String)]) -> String {
+    environment
+        .iter()
+        .map(|(key, value)| format!("export {key}={}", shell_escape(value)))
+        .collect::<Vec<String>>()
+        .join(" && ")
+}
+
+fn render_exec_command(executable: &Path, args: &[String]) -> String {
+    let mut tokens = Vec::with_capacity(args.len() + 1);
+    tokens.push(shell_escape(executable.to_string_lossy().as_ref()));
+    for arg in args {
+        tokens.push(shell_escape(arg));
+    }
+    format!("exec {}", tokens.join(" "))
+}
+
+fn with_optional_bootstrap(repo_root: &Path, command: &str, no_bootstrap: bool) -> String {
+    if no_bootstrap {
+        return command.to_string();
+    }
+
+    let bootstrap_script = repo_root.join("build").join("envsetup.sh");
+    format!(
+        "source {} highest >/dev/null 2>&1 && {command}",
+        shell_escape(bootstrap_script.to_string_lossy().as_ref())
+    )
+}

--- a/utils/transport-smoke-suite/src/report.rs
+++ b/utils/transport-smoke-suite/src/report.rs
@@ -1,0 +1,249 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+use crate::claims::ClaimOutcome;
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+pub const SCENARIO_REPORT_SCHEMA_VERSION: &str = "1.1";
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct PhaseTiming {
+    pub phase: String,
+    pub start_ts: String,
+    pub end_ts: String,
+    pub duration_ms: u128,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ProcessMetadata {
+    pub name: String,
+    pub pid: i32,
+    pub process_group_id: i32,
+    pub command: String,
+    pub workdir: String,
+    pub log_file: String,
+    pub exit_status: Option<i32>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ScenarioReport {
+    pub schema_version: String,
+    pub scenario_id: String,
+    pub transport_family: String,
+    pub pass: bool,
+    pub exit_code: i32,
+    pub phase_timings: Vec<PhaseTiming>,
+    pub processes: Vec<ProcessMetadata>,
+    pub claim_outcomes: Vec<ClaimOutcome>,
+    pub forbidden_claim_outcomes: Vec<ClaimOutcome>,
+    pub failure_reason: Option<String>,
+    pub repro_command: String,
+    pub artifact_dir: String,
+    #[serde(default)]
+    pub claims_source_path: Option<String>,
+    pub start_ts: String,
+    pub end_ts: String,
+    pub duration_ms: u128,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct MatrixScenarioSummary {
+    pub scenario_id: String,
+    pub pass: bool,
+    pub exit_code: i32,
+    pub artifact_dir: Option<String>,
+    pub failure_reason: Option<String>,
+    pub duration_ms: u128,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct FailedScenarioSummary {
+    pub scenario_id: String,
+    pub failure_reason: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct MatrixSummary {
+    pub schema_version: String,
+    pub selected_scenarios: Vec<String>,
+    pub pass_count: usize,
+    pub fail_count: usize,
+    pub total_duration_ms: u128,
+    pub scenarios: Vec<MatrixScenarioSummary>,
+    pub failed_scenarios: Vec<FailedScenarioSummary>,
+    pub aggregate_exit_rationale: String,
+    pub start_ts: String,
+    pub end_ts: String,
+}
+
+pub fn write_scenario_report(
+    report: &ScenarioReport,
+    artifacts_dir: &Path,
+) -> Result<(PathBuf, PathBuf)> {
+    fs::create_dir_all(artifacts_dir)
+        .with_context(|| format!("unable to create artifact dir {}", artifacts_dir.display()))?;
+
+    let scenario_report_json = artifacts_dir.join("scenario-report.json");
+    let scenario_report_txt = artifacts_dir.join("scenario-report.txt");
+
+    let json_payload = serde_json::to_string_pretty(report).context("serialize scenario report")?;
+    fs::write(&scenario_report_json, json_payload).with_context(|| {
+        format!(
+            "unable to write scenario report JSON {}",
+            scenario_report_json.display()
+        )
+    })?;
+
+    fs::write(&scenario_report_txt, render_scenario_summary_text(report)).with_context(|| {
+        format!(
+            "unable to write scenario report text {}",
+            scenario_report_txt.display()
+        )
+    })?;
+
+    Ok((scenario_report_json, scenario_report_txt))
+}
+
+pub fn write_matrix_summary(
+    summary: &MatrixSummary,
+    artifacts_dir: &Path,
+) -> Result<(PathBuf, PathBuf)> {
+    fs::create_dir_all(artifacts_dir)
+        .with_context(|| format!("unable to create artifact dir {}", artifacts_dir.display()))?;
+
+    let matrix_summary_json = artifacts_dir.join("matrix-summary.json");
+    let matrix_summary_txt = artifacts_dir.join("matrix-summary.txt");
+
+    let json_payload = serde_json::to_string_pretty(summary).context("serialize matrix summary")?;
+    fs::write(&matrix_summary_json, json_payload).with_context(|| {
+        format!(
+            "unable to write matrix summary JSON {}",
+            matrix_summary_json.display()
+        )
+    })?;
+
+    fs::write(&matrix_summary_txt, render_matrix_summary_text(summary)).with_context(|| {
+        format!(
+            "unable to write matrix summary text {}",
+            matrix_summary_txt.display()
+        )
+    })?;
+
+    Ok((matrix_summary_json, matrix_summary_txt))
+}
+
+pub fn load_scenario_report(report_path: &Path) -> Result<ScenarioReport> {
+    let payload = fs::read_to_string(report_path)
+        .with_context(|| format!("unable to read scenario report {}", report_path.display()))?;
+    serde_json::from_str(&payload)
+        .with_context(|| format!("unable to parse scenario report {}", report_path.display()))
+}
+
+pub fn timestamp_to_string(timestamp: DateTime<Utc>) -> String {
+    timestamp.to_rfc3339()
+}
+
+fn render_scenario_summary_text(report: &ScenarioReport) -> String {
+    let mut lines = vec![
+        format!("scenario_id: {}", report.scenario_id),
+        format!("transport_family: {}", report.transport_family),
+        format!("status: {}", if report.pass { "PASS" } else { "FAIL" }),
+        format!("exit_code: {}", report.exit_code),
+        format!("artifact_dir: {}", report.artifact_dir),
+        format!(
+            "claims_source_path: {}",
+            report
+                .claims_source_path
+                .as_deref()
+                .unwrap_or("<not available>")
+        ),
+        format!("duration_ms: {}", report.duration_ms),
+        format!("repro_command: {}", report.repro_command),
+    ];
+
+    if let Some(reason) = &report.failure_reason {
+        lines.push(format!("failure_reason: {reason}"));
+    }
+
+    lines.push("phase_timings:".to_string());
+    for phase in &report.phase_timings {
+        lines.push(format!(
+            "  - {} (duration_ms={})",
+            phase.phase, phase.duration_ms
+        ));
+    }
+
+    lines.push("claim_outcomes:".to_string());
+    for outcome in report
+        .claim_outcomes
+        .iter()
+        .chain(report.forbidden_claim_outcomes.iter())
+    {
+        lines.push(format!(
+            "  - {}: {} (observed={}, min={}, pattern='{}')",
+            outcome.claim_id,
+            if outcome.pass { "PASS" } else { "FAIL" },
+            outcome.observed_count,
+            outcome.min_count,
+            outcome.pattern
+        ));
+    }
+
+    lines.join("\n")
+}
+
+fn render_matrix_summary_text(summary: &MatrixSummary) -> String {
+    let mut lines = vec![
+        format!(
+            "selected_scenarios: {}",
+            summary.selected_scenarios.join(", ")
+        ),
+        format!("pass_count: {}", summary.pass_count),
+        format!("fail_count: {}", summary.fail_count),
+        format!("total_duration_ms: {}", summary.total_duration_ms),
+        format!(
+            "aggregate_exit_rationale: {}",
+            summary.aggregate_exit_rationale
+        ),
+    ];
+
+    lines.push("scenarios:".to_string());
+    for scenario in &summary.scenarios {
+        lines.push(format!(
+            "  - {}: {} (exit_code={}, duration_ms={}, artifact_dir={})",
+            scenario.scenario_id,
+            if scenario.pass { "PASS" } else { "FAIL" },
+            scenario.exit_code,
+            scenario.duration_ms,
+            scenario
+                .artifact_dir
+                .as_deref()
+                .unwrap_or("<not available>")
+        ));
+    }
+
+    lines
+        .into_iter()
+        .chain(summary.failed_scenarios.iter().map(|failed| {
+            format!(
+                "failed: {} -> {}",
+                failed.scenario_id, failed.failure_reason
+            )
+        }))
+        .collect::<Vec<String>>()
+        .join("\n")
+}

--- a/utils/transport-smoke-suite/src/scenario.rs
+++ b/utils/transport-smoke-suite/src/scenario.rs
@@ -1,0 +1,1379 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+use crate::claims::{evaluate_claims, load_claims_for_scenario, split_claim_outcomes, Thresholds};
+use crate::env;
+use crate::logs;
+use crate::process::{run_shell_command, shell_escape, ManagedProcess, ProcessSpec};
+use crate::report::{self, PhaseTiming, ProcessMetadata, ScenarioReport};
+use anyhow::{anyhow, Context, Result};
+use chrono::Utc;
+use clap::Args;
+use std::cmp::min;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+pub const SCENARIO_IDS: [&str; 8] = [
+    "smoke-zenoh-mqtt-rr-zenoh-client-mqtt-service",
+    "smoke-zenoh-mqtt-rr-mqtt-client-zenoh-service",
+    "smoke-zenoh-mqtt-ps-zenoh-publisher-mqtt-subscriber",
+    "smoke-zenoh-mqtt-ps-mqtt-publisher-zenoh-subscriber",
+    "smoke-zenoh-someip-rr-zenoh-client-someip-service",
+    "smoke-zenoh-someip-rr-someip-client-zenoh-service",
+    "smoke-zenoh-someip-ps-zenoh-publisher-someip-subscriber",
+    "smoke-zenoh-someip-ps-someip-publisher-zenoh-subscriber",
+];
+
+const NO_ARGS: &[&str] = &[];
+const MQTT_STREAMER_ENV: &[(&str, &str)] = &[(
+    "RUST_LOG",
+    "up_streamer=debug,up_transport_mqtt5=debug,configurable_streamer=debug",
+)];
+const SOMEIP_STREAMER_ENV: &[(&str, &str)] = &[(
+    "RUST_LOG",
+    "up_transport_vsomeip=trace,up_streamer=debug,up_linux_streamer=debug,example_streamer_uses=debug",
+)];
+const ACTIVE_DEBUG_ENV: &[(&str, &str)] = &[("RUST_LOG", "info,example_streamer_uses=debug")];
+const PASSIVE_INFO_ENV: &[(&str, &str)] = &[("RUST_LOG", "info,example_streamer_uses=debug")];
+
+const PASSIVE_MQTT_SUBSCRIBER_ARGS_A: &[&str] = &[
+    "--uauthority",
+    "authority-a",
+    "--uentity",
+    "0x5678",
+    "--uversion",
+    "0x1",
+    "--resource",
+    "0x1234",
+    "--source-authority",
+    "authority-b",
+    "--source-uentity",
+    "0x3039",
+    "--source-uversion",
+    "0x1",
+    "--source-resource",
+    "0x8001",
+    "--broker-uri",
+    "localhost:1883",
+];
+
+const PASSIVE_ZENOH_SUBSCRIBER_ARGS_B: &[&str] = &[
+    "--uauthority",
+    "authority-b",
+    "--uentity",
+    "0x5678",
+    "--uversion",
+    "0x1",
+    "--resource",
+    "0x1234",
+    "--source-authority",
+    "authority-a",
+    "--source-uentity",
+    "0x5BA0",
+    "--source-uversion",
+    "0x1",
+    "--source-resource",
+    "0x8001",
+];
+
+const PASSIVE_SOMEIP_SUBSCRIBER_ARGS_A: &[&str] = &[
+    "--uauthority",
+    "authority-a",
+    "--uentity",
+    "0x5678",
+    "--uversion",
+    "0x1",
+    "--resource",
+    "0x0",
+    "--source-authority",
+    "authority-b",
+    "--source-uentity",
+    "0x3039",
+    "--source-uversion",
+    "0x1",
+    "--source-resource",
+    "0x8001",
+    "--remote-authority",
+    "authority-b",
+    "--vsomeip-config",
+    "example-streamer-uses/vsomeip-configs/someip_client.json",
+];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransportFamily {
+    Mqtt,
+    Someip,
+}
+
+impl TransportFamily {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Mqtt => "mqtt",
+            Self::Someip => "someip",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct ProcessTemplate {
+    pub name: &'static str,
+    pub workdir: &'static str,
+    pub binary: &'static str,
+    pub args: &'static [&'static str],
+    pub env: &'static [(&'static str, &'static str)],
+    pub log_file: &'static str,
+    pub readiness_marker: Option<&'static str>,
+    pub readiness_timeout_secs: Option<u64>,
+    pub bounded_sender: bool,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct ScenarioTemplate {
+    pub id: &'static str,
+    pub transport_family: TransportFamily,
+    pub build_commands: &'static [&'static str],
+    pub required_paths: &'static [&'static str],
+    pub stale_process_signatures: &'static [&'static str],
+    pub requires_docker: bool,
+    pub requires_vsomeip_runtime: bool,
+    pub streamer: ProcessTemplate,
+    pub passive: ProcessTemplate,
+    pub active: ProcessTemplate,
+    pub hard_timeout_secs_default: u64,
+}
+
+const BUILD_MQTT_RR_ZENOH_CLIENT: &[&str] = &[
+    "cargo build -p configurable-streamer",
+    "cargo build -p example-streamer-uses --bin zenoh_client --features zenoh-transport",
+    "cargo build -p example-streamer-uses --bin mqtt_service --features mqtt-transport",
+];
+const BUILD_MQTT_RR_MQTT_CLIENT: &[&str] = &[
+    "cargo build -p configurable-streamer",
+    "cargo build -p example-streamer-uses --bin mqtt_client --features mqtt-transport",
+    "cargo build -p example-streamer-uses --bin zenoh_service --features zenoh-transport",
+];
+const BUILD_MQTT_PS_ZENOH_PUBLISHER: &[&str] = &[
+    "cargo build -p configurable-streamer",
+    "cargo build -p example-streamer-uses --bin zenoh_publisher --features zenoh-transport",
+    "cargo build -p example-streamer-uses --bin mqtt_subscriber --features mqtt-transport",
+];
+const BUILD_MQTT_PS_MQTT_PUBLISHER: &[&str] = &[
+    "cargo build -p configurable-streamer",
+    "cargo build -p example-streamer-uses --bin mqtt_publisher --features mqtt-transport",
+    "cargo build -p example-streamer-uses --bin zenoh_subscriber --features zenoh-transport",
+];
+const BUILD_SOMEIP_RR_ZENOH_CLIENT: &[&str] = &[
+    "cargo build -p up-linux-streamer --bin zenoh_someip --features zenoh-transport,vsomeip-transport,bundled-vsomeip",
+    "cargo build -p example-streamer-uses --bin zenoh_client --features zenoh-transport",
+    "cargo build -p example-streamer-uses --bin someip_service --features vsomeip-transport,bundled-vsomeip",
+];
+const BUILD_SOMEIP_RR_SOMEIP_CLIENT: &[&str] = &[
+    "cargo build -p up-linux-streamer --bin zenoh_someip --features zenoh-transport,vsomeip-transport,bundled-vsomeip",
+    "cargo build -p example-streamer-uses --bin someip_client --features vsomeip-transport,bundled-vsomeip",
+    "cargo build -p example-streamer-uses --bin zenoh_service --features zenoh-transport",
+];
+const BUILD_SOMEIP_PS_ZENOH_PUBLISHER: &[&str] = &[
+    "cargo build -p up-linux-streamer --bin zenoh_someip --features zenoh-transport,vsomeip-transport,bundled-vsomeip",
+    "cargo build -p example-streamer-uses --bin zenoh_publisher --features zenoh-transport",
+    "cargo build -p example-streamer-uses --bin someip_subscriber --features vsomeip-transport,bundled-vsomeip",
+];
+const BUILD_SOMEIP_PS_SOMEIP_PUBLISHER: &[&str] = &[
+    "cargo build -p up-linux-streamer --bin zenoh_someip --features zenoh-transport,vsomeip-transport,bundled-vsomeip",
+    "cargo build -p example-streamer-uses --bin someip_publisher --features vsomeip-transport,bundled-vsomeip",
+    "cargo build -p example-streamer-uses --bin zenoh_subscriber --features zenoh-transport",
+];
+
+const REQUIRED_MQTT_PATHS: &[&str] = &[
+    "configurable-streamer/CONFIG.json5",
+    "configurable-streamer/ZENOH_CONFIG.json5",
+    "utils/mosquitto/docker-compose.yaml",
+];
+const REQUIRED_SOMEIP_PATHS: &[&str] = &[
+    "example-streamer-implementations/DEFAULT_CONFIG.json5",
+    "example-streamer-uses/vsomeip-configs/someip_client.json",
+    "example-streamer-uses/vsomeip-configs/someip_publisher.json",
+    "example-streamer-uses/vsomeip-configs/someip_service.json",
+    "example-streamer-uses/vsomeip-configs/someip_subscriber.json",
+];
+
+const SCENARIO_MQTT_RR_ZENOH_CLIENT_MQTT_SERVICE: ScenarioTemplate = ScenarioTemplate {
+    id: "smoke-zenoh-mqtt-rr-zenoh-client-mqtt-service",
+    transport_family: TransportFamily::Mqtt,
+    build_commands: BUILD_MQTT_RR_ZENOH_CLIENT,
+    required_paths: REQUIRED_MQTT_PATHS,
+    stale_process_signatures: &["configurable-streamer", "mqtt_service", "zenoh_client"],
+    requires_docker: true,
+    requires_vsomeip_runtime: false,
+    streamer: ProcessTemplate {
+        name: "streamer",
+        workdir: "configurable-streamer",
+        binary: "configurable-streamer",
+        args: &["--config", "CONFIG.json5"],
+        env: MQTT_STREAMER_ENV,
+        log_file: "streamer.log",
+        readiness_marker: Some(env::READY_STREAMER_INITIALIZED),
+        readiness_timeout_secs: Some(env::STREAMER_READY_TIMEOUT_SECS),
+        bounded_sender: false,
+    },
+    passive: ProcessTemplate {
+        name: "service",
+        workdir: ".",
+        binary: "mqtt_service",
+        args: &["--broker-uri", "localhost:1883"],
+        env: PASSIVE_INFO_ENV,
+        log_file: "service.log",
+        readiness_marker: Some(env::READY_LISTENER_REGISTERED),
+        readiness_timeout_secs: Some(env::PASSIVE_READY_TIMEOUT_SECS),
+        bounded_sender: false,
+    },
+    active: ProcessTemplate {
+        name: "client",
+        workdir: ".",
+        binary: "zenoh_client",
+        args: NO_ARGS,
+        env: ACTIVE_DEBUG_ENV,
+        log_file: "client.log",
+        readiness_marker: None,
+        readiness_timeout_secs: None,
+        bounded_sender: true,
+    },
+    hard_timeout_secs_default: env::MQTT_HARD_TIMEOUT_SECS,
+};
+
+const SCENARIO_MQTT_RR_MQTT_CLIENT_ZENOH_SERVICE: ScenarioTemplate = ScenarioTemplate {
+    id: "smoke-zenoh-mqtt-rr-mqtt-client-zenoh-service",
+    transport_family: TransportFamily::Mqtt,
+    build_commands: BUILD_MQTT_RR_MQTT_CLIENT,
+    required_paths: REQUIRED_MQTT_PATHS,
+    stale_process_signatures: &["configurable-streamer", "zenoh_service", "mqtt_client"],
+    requires_docker: true,
+    requires_vsomeip_runtime: false,
+    streamer: ProcessTemplate {
+        name: "streamer",
+        workdir: "configurable-streamer",
+        binary: "configurable-streamer",
+        args: &["--config", "CONFIG.json5"],
+        env: MQTT_STREAMER_ENV,
+        log_file: "streamer.log",
+        readiness_marker: Some(env::READY_STREAMER_INITIALIZED),
+        readiness_timeout_secs: Some(env::STREAMER_READY_TIMEOUT_SECS),
+        bounded_sender: false,
+    },
+    passive: ProcessTemplate {
+        name: "service",
+        workdir: ".",
+        binary: "zenoh_service",
+        args: NO_ARGS,
+        env: PASSIVE_INFO_ENV,
+        log_file: "service.log",
+        readiness_marker: Some(env::READY_LISTENER_REGISTERED),
+        readiness_timeout_secs: Some(env::PASSIVE_READY_TIMEOUT_SECS),
+        bounded_sender: false,
+    },
+    active: ProcessTemplate {
+        name: "client",
+        workdir: ".",
+        binary: "mqtt_client",
+        args: &["--broker-uri", "localhost:1883"],
+        env: ACTIVE_DEBUG_ENV,
+        log_file: "client.log",
+        readiness_marker: None,
+        readiness_timeout_secs: None,
+        bounded_sender: true,
+    },
+    hard_timeout_secs_default: env::MQTT_HARD_TIMEOUT_SECS,
+};
+
+const SCENARIO_MQTT_PS_ZENOH_PUBLISHER_MQTT_SUBSCRIBER: ScenarioTemplate = ScenarioTemplate {
+    id: "smoke-zenoh-mqtt-ps-zenoh-publisher-mqtt-subscriber",
+    transport_family: TransportFamily::Mqtt,
+    build_commands: BUILD_MQTT_PS_ZENOH_PUBLISHER,
+    required_paths: REQUIRED_MQTT_PATHS,
+    stale_process_signatures: &[
+        "configurable-streamer",
+        "mqtt_subscriber",
+        "zenoh_publisher",
+    ],
+    requires_docker: true,
+    requires_vsomeip_runtime: false,
+    streamer: ProcessTemplate {
+        name: "streamer",
+        workdir: "configurable-streamer",
+        binary: "configurable-streamer",
+        args: &["--config", "CONFIG.json5"],
+        env: MQTT_STREAMER_ENV,
+        log_file: "streamer.log",
+        readiness_marker: Some(env::READY_STREAMER_INITIALIZED),
+        readiness_timeout_secs: Some(env::STREAMER_READY_TIMEOUT_SECS),
+        bounded_sender: false,
+    },
+    passive: ProcessTemplate {
+        name: "subscriber",
+        workdir: ".",
+        binary: "mqtt_subscriber",
+        args: PASSIVE_MQTT_SUBSCRIBER_ARGS_A,
+        env: PASSIVE_INFO_ENV,
+        log_file: "subscriber.log",
+        readiness_marker: Some(env::READY_LISTENER_REGISTERED),
+        readiness_timeout_secs: Some(env::PASSIVE_READY_TIMEOUT_SECS),
+        bounded_sender: false,
+    },
+    active: ProcessTemplate {
+        name: "publisher",
+        workdir: ".",
+        binary: "zenoh_publisher",
+        args: NO_ARGS,
+        env: ACTIVE_DEBUG_ENV,
+        log_file: "publisher.log",
+        readiness_marker: None,
+        readiness_timeout_secs: None,
+        bounded_sender: true,
+    },
+    hard_timeout_secs_default: env::MQTT_HARD_TIMEOUT_SECS,
+};
+
+const SCENARIO_MQTT_PS_MQTT_PUBLISHER_ZENOH_SUBSCRIBER: ScenarioTemplate = ScenarioTemplate {
+    id: "smoke-zenoh-mqtt-ps-mqtt-publisher-zenoh-subscriber",
+    transport_family: TransportFamily::Mqtt,
+    build_commands: BUILD_MQTT_PS_MQTT_PUBLISHER,
+    required_paths: REQUIRED_MQTT_PATHS,
+    stale_process_signatures: &[
+        "configurable-streamer",
+        "zenoh_subscriber",
+        "mqtt_publisher",
+    ],
+    requires_docker: true,
+    requires_vsomeip_runtime: false,
+    streamer: ProcessTemplate {
+        name: "streamer",
+        workdir: "configurable-streamer",
+        binary: "configurable-streamer",
+        args: &["--config", "CONFIG.json5"],
+        env: MQTT_STREAMER_ENV,
+        log_file: "streamer.log",
+        readiness_marker: Some(env::READY_STREAMER_INITIALIZED),
+        readiness_timeout_secs: Some(env::STREAMER_READY_TIMEOUT_SECS),
+        bounded_sender: false,
+    },
+    passive: ProcessTemplate {
+        name: "subscriber",
+        workdir: ".",
+        binary: "zenoh_subscriber",
+        args: PASSIVE_ZENOH_SUBSCRIBER_ARGS_B,
+        env: PASSIVE_INFO_ENV,
+        log_file: "subscriber.log",
+        readiness_marker: Some(env::READY_LISTENER_REGISTERED),
+        readiness_timeout_secs: Some(env::PASSIVE_READY_TIMEOUT_SECS),
+        bounded_sender: false,
+    },
+    active: ProcessTemplate {
+        name: "publisher",
+        workdir: ".",
+        binary: "mqtt_publisher",
+        args: &["--broker-uri", "localhost:1883"],
+        env: ACTIVE_DEBUG_ENV,
+        log_file: "publisher.log",
+        readiness_marker: None,
+        readiness_timeout_secs: None,
+        bounded_sender: true,
+    },
+    hard_timeout_secs_default: env::MQTT_HARD_TIMEOUT_SECS,
+};
+
+const SCENARIO_SOMEIP_RR_ZENOH_CLIENT_SOMEIP_SERVICE: ScenarioTemplate = ScenarioTemplate {
+    id: "smoke-zenoh-someip-rr-zenoh-client-someip-service",
+    transport_family: TransportFamily::Someip,
+    build_commands: BUILD_SOMEIP_RR_ZENOH_CLIENT,
+    required_paths: REQUIRED_SOMEIP_PATHS,
+    stale_process_signatures: &["zenoh_someip", "someip_service", "zenoh_client"],
+    requires_docker: false,
+    requires_vsomeip_runtime: true,
+    streamer: ProcessTemplate {
+        name: "streamer",
+        workdir: "example-streamer-implementations",
+        binary: "zenoh_someip",
+        args: &["--config", "DEFAULT_CONFIG.json5"],
+        env: SOMEIP_STREAMER_ENV,
+        log_file: "streamer.log",
+        readiness_marker: Some(env::READY_STREAMER_INITIALIZED),
+        readiness_timeout_secs: Some(env::STREAMER_READY_TIMEOUT_SECS),
+        bounded_sender: false,
+    },
+    passive: ProcessTemplate {
+        name: "service",
+        workdir: ".",
+        binary: "someip_service",
+        args: NO_ARGS,
+        env: PASSIVE_INFO_ENV,
+        log_file: "service.log",
+        readiness_marker: Some(env::READY_LISTENER_REGISTERED),
+        readiness_timeout_secs: Some(env::PASSIVE_READY_TIMEOUT_SECS),
+        bounded_sender: false,
+    },
+    active: ProcessTemplate {
+        name: "client",
+        workdir: ".",
+        binary: "zenoh_client",
+        args: NO_ARGS,
+        env: ACTIVE_DEBUG_ENV,
+        log_file: "client.log",
+        readiness_marker: None,
+        readiness_timeout_secs: None,
+        bounded_sender: true,
+    },
+    hard_timeout_secs_default: env::SOMEIP_HARD_TIMEOUT_SECS,
+};
+
+const SCENARIO_SOMEIP_RR_SOMEIP_CLIENT_ZENOH_SERVICE: ScenarioTemplate = ScenarioTemplate {
+    id: "smoke-zenoh-someip-rr-someip-client-zenoh-service",
+    transport_family: TransportFamily::Someip,
+    build_commands: BUILD_SOMEIP_RR_SOMEIP_CLIENT,
+    required_paths: REQUIRED_SOMEIP_PATHS,
+    stale_process_signatures: &["zenoh_someip", "zenoh_service", "someip_client"],
+    requires_docker: false,
+    requires_vsomeip_runtime: true,
+    streamer: ProcessTemplate {
+        name: "streamer",
+        workdir: "example-streamer-implementations",
+        binary: "zenoh_someip",
+        args: &["--config", "DEFAULT_CONFIG.json5"],
+        env: SOMEIP_STREAMER_ENV,
+        log_file: "streamer.log",
+        readiness_marker: Some(env::READY_STREAMER_INITIALIZED),
+        readiness_timeout_secs: Some(env::STREAMER_READY_TIMEOUT_SECS),
+        bounded_sender: false,
+    },
+    passive: ProcessTemplate {
+        name: "service",
+        workdir: ".",
+        binary: "zenoh_service",
+        args: NO_ARGS,
+        env: PASSIVE_INFO_ENV,
+        log_file: "service.log",
+        readiness_marker: Some(env::READY_LISTENER_REGISTERED),
+        readiness_timeout_secs: Some(env::PASSIVE_READY_TIMEOUT_SECS),
+        bounded_sender: false,
+    },
+    active: ProcessTemplate {
+        name: "client",
+        workdir: ".",
+        binary: "someip_client",
+        args: NO_ARGS,
+        env: ACTIVE_DEBUG_ENV,
+        log_file: "client.log",
+        readiness_marker: None,
+        readiness_timeout_secs: None,
+        bounded_sender: true,
+    },
+    hard_timeout_secs_default: env::SOMEIP_HARD_TIMEOUT_SECS,
+};
+
+const SCENARIO_SOMEIP_PS_ZENOH_PUBLISHER_SOMEIP_SUBSCRIBER: ScenarioTemplate = ScenarioTemplate {
+    id: "smoke-zenoh-someip-ps-zenoh-publisher-someip-subscriber",
+    transport_family: TransportFamily::Someip,
+    build_commands: BUILD_SOMEIP_PS_ZENOH_PUBLISHER,
+    required_paths: REQUIRED_SOMEIP_PATHS,
+    stale_process_signatures: &["zenoh_someip", "someip_subscriber", "zenoh_publisher"],
+    requires_docker: false,
+    requires_vsomeip_runtime: true,
+    streamer: ProcessTemplate {
+        name: "streamer",
+        workdir: "example-streamer-implementations",
+        binary: "zenoh_someip",
+        args: &["--config", "DEFAULT_CONFIG.json5"],
+        env: SOMEIP_STREAMER_ENV,
+        log_file: "streamer.log",
+        readiness_marker: Some(env::READY_STREAMER_INITIALIZED),
+        readiness_timeout_secs: Some(env::STREAMER_READY_TIMEOUT_SECS),
+        bounded_sender: false,
+    },
+    passive: ProcessTemplate {
+        name: "subscriber",
+        workdir: ".",
+        binary: "someip_subscriber",
+        args: PASSIVE_SOMEIP_SUBSCRIBER_ARGS_A,
+        env: PASSIVE_INFO_ENV,
+        log_file: "subscriber.log",
+        readiness_marker: Some(env::READY_LISTENER_REGISTERED),
+        readiness_timeout_secs: Some(env::PASSIVE_READY_TIMEOUT_SECS),
+        bounded_sender: false,
+    },
+    active: ProcessTemplate {
+        name: "publisher",
+        workdir: ".",
+        binary: "zenoh_publisher",
+        args: NO_ARGS,
+        env: ACTIVE_DEBUG_ENV,
+        log_file: "publisher.log",
+        readiness_marker: None,
+        readiness_timeout_secs: None,
+        bounded_sender: true,
+    },
+    hard_timeout_secs_default: env::SOMEIP_HARD_TIMEOUT_SECS,
+};
+
+const SCENARIO_SOMEIP_PS_SOMEIP_PUBLISHER_ZENOH_SUBSCRIBER: ScenarioTemplate = ScenarioTemplate {
+    id: "smoke-zenoh-someip-ps-someip-publisher-zenoh-subscriber",
+    transport_family: TransportFamily::Someip,
+    build_commands: BUILD_SOMEIP_PS_SOMEIP_PUBLISHER,
+    required_paths: REQUIRED_SOMEIP_PATHS,
+    stale_process_signatures: &["zenoh_someip", "zenoh_subscriber", "someip_publisher"],
+    requires_docker: false,
+    requires_vsomeip_runtime: true,
+    streamer: ProcessTemplate {
+        name: "streamer",
+        workdir: "example-streamer-implementations",
+        binary: "zenoh_someip",
+        args: &["--config", "DEFAULT_CONFIG.json5"],
+        env: SOMEIP_STREAMER_ENV,
+        log_file: "streamer.log",
+        readiness_marker: Some(env::READY_STREAMER_INITIALIZED),
+        readiness_timeout_secs: Some(env::STREAMER_READY_TIMEOUT_SECS),
+        bounded_sender: false,
+    },
+    passive: ProcessTemplate {
+        name: "subscriber",
+        workdir: ".",
+        binary: "zenoh_subscriber",
+        args: PASSIVE_ZENOH_SUBSCRIBER_ARGS_B,
+        env: PASSIVE_INFO_ENV,
+        log_file: "subscriber.log",
+        readiness_marker: Some(env::READY_LISTENER_REGISTERED),
+        readiness_timeout_secs: Some(env::PASSIVE_READY_TIMEOUT_SECS),
+        bounded_sender: false,
+    },
+    active: ProcessTemplate {
+        name: "publisher",
+        workdir: ".",
+        binary: "someip_publisher",
+        args: NO_ARGS,
+        env: ACTIVE_DEBUG_ENV,
+        log_file: "publisher.log",
+        readiness_marker: None,
+        readiness_timeout_secs: None,
+        bounded_sender: true,
+    },
+    hard_timeout_secs_default: env::SOMEIP_HARD_TIMEOUT_SECS,
+};
+
+#[derive(Debug, Clone, Args)]
+pub struct ScenarioCliArgs {
+    #[arg(long)]
+    pub skip_build: bool,
+
+    #[arg(long)]
+    pub artifacts_root: Option<PathBuf>,
+
+    #[arg(long)]
+    pub claims_path: Option<PathBuf>,
+
+    #[arg(long, default_value_t = env::DEFAULT_SEND_COUNT)]
+    pub send_count: u64,
+
+    #[arg(long, default_value_t = env::DEFAULT_SEND_INTERVAL_MS)]
+    pub send_interval_ms: u64,
+
+    #[arg(long)]
+    pub scenario_timeout_secs: Option<u64>,
+
+    #[arg(long)]
+    pub expected_branch: Option<String>,
+
+    #[arg(long)]
+    pub no_bootstrap: bool,
+
+    #[arg(long, default_value_t = env::DEFAULT_ENDPOINT_CLAIM_MIN_COUNT)]
+    pub endpoint_claim_min_count: usize,
+
+    #[arg(long, default_value_t = env::DEFAULT_EGRESS_SEND_ATTEMPT_MIN_COUNT)]
+    pub egress_send_attempt_min_count: usize,
+
+    #[arg(long, default_value_t = env::DEFAULT_EGRESS_SEND_OK_MIN_COUNT)]
+    pub egress_send_ok_min_count: usize,
+
+    #[arg(long, default_value_t = env::DEFAULT_EGRESS_WORKER_MIN_COUNT)]
+    pub egress_worker_min_count: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct ScenarioRunResult {
+    pub pass: bool,
+    pub exit_code: i32,
+    pub artifact_dir: PathBuf,
+    pub scenario_report_json: PathBuf,
+    pub scenario_report_txt: PathBuf,
+    pub failure_reason: Option<String>,
+}
+
+pub fn scenario_ids() -> &'static [&'static str] {
+    &SCENARIO_IDS
+}
+
+pub fn scenario_template(scenario_id: &str) -> Option<&'static ScenarioTemplate> {
+    match scenario_id {
+        "smoke-zenoh-mqtt-rr-zenoh-client-mqtt-service" => {
+            Some(&SCENARIO_MQTT_RR_ZENOH_CLIENT_MQTT_SERVICE)
+        }
+        "smoke-zenoh-mqtt-rr-mqtt-client-zenoh-service" => {
+            Some(&SCENARIO_MQTT_RR_MQTT_CLIENT_ZENOH_SERVICE)
+        }
+        "smoke-zenoh-mqtt-ps-zenoh-publisher-mqtt-subscriber" => {
+            Some(&SCENARIO_MQTT_PS_ZENOH_PUBLISHER_MQTT_SUBSCRIBER)
+        }
+        "smoke-zenoh-mqtt-ps-mqtt-publisher-zenoh-subscriber" => {
+            Some(&SCENARIO_MQTT_PS_MQTT_PUBLISHER_ZENOH_SUBSCRIBER)
+        }
+        "smoke-zenoh-someip-rr-zenoh-client-someip-service" => {
+            Some(&SCENARIO_SOMEIP_RR_ZENOH_CLIENT_SOMEIP_SERVICE)
+        }
+        "smoke-zenoh-someip-rr-someip-client-zenoh-service" => {
+            Some(&SCENARIO_SOMEIP_RR_SOMEIP_CLIENT_ZENOH_SERVICE)
+        }
+        "smoke-zenoh-someip-ps-zenoh-publisher-someip-subscriber" => {
+            Some(&SCENARIO_SOMEIP_PS_ZENOH_PUBLISHER_SOMEIP_SUBSCRIBER)
+        }
+        "smoke-zenoh-someip-ps-someip-publisher-zenoh-subscriber" => {
+            Some(&SCENARIO_SOMEIP_PS_SOMEIP_PUBLISHER_ZENOH_SUBSCRIBER)
+        }
+        _ => None,
+    }
+}
+
+pub async fn run_scenario(
+    scenario_id: &str,
+    cli_args: ScenarioCliArgs,
+) -> Result<ScenarioRunResult> {
+    let template = scenario_template(scenario_id)
+        .ok_or_else(|| anyhow!("unknown scenario id '{}'", scenario_id))?;
+
+    let repo_root = env::repo_root()?;
+    let expected_branch = env::resolve_expected_branch(cli_args.expected_branch.clone());
+    let artifacts_root = env::resolve_artifacts_root(&repo_root, cli_args.artifacts_root.clone());
+    let artifact_dir = artifacts_root
+        .join(template.id)
+        .join(env::scenario_timestamp());
+    std::fs::create_dir_all(&artifact_dir)
+        .with_context(|| format!("unable to create artifact dir {}", artifact_dir.display()))?;
+
+    let scenario_start_wall = Utc::now();
+    let scenario_start_instant = Instant::now();
+    let hard_timeout_secs = cli_args
+        .scenario_timeout_secs
+        .unwrap_or(template.hard_timeout_secs_default);
+    let scenario_deadline = scenario_start_instant + Duration::from_secs(hard_timeout_secs);
+
+    let thresholds = Thresholds {
+        endpoint_communication_min_count: cli_args.endpoint_claim_min_count,
+        egress_send_attempt_min_count: cli_args.egress_send_attempt_min_count,
+        egress_send_ok_min_count: cli_args.egress_send_ok_min_count,
+        egress_worker_create_or_reuse_min_count: cli_args.egress_worker_min_count,
+    };
+
+    let mut phase_timings = Vec::new();
+    let mut failure_reason = None;
+    let mut claim_outcomes = Vec::new();
+    let mut forbidden_claim_outcomes = Vec::new();
+    let mut loaded_claims = Vec::new();
+    let mut claims_source_path: Option<PathBuf> = None;
+
+    let mut streamer_process: Option<ManagedProcess> = None;
+    let mut passive_process: Option<ManagedProcess> = None;
+    let mut active_process: Option<ManagedProcess> = None;
+    let mut mqtt_broker_started = false;
+    let mut vsomeip_runtime_lib: Option<PathBuf> = None;
+
+    let preflight_result = execute_phase("Preflight", &mut phase_timings, || async {
+        ensure_remaining_timeout(scenario_deadline, "Preflight")?;
+
+        env::enforce_expected_branch(&repo_root, expected_branch.as_deref()).await?;
+        env::ensure_paths_exist(&repo_root, template.required_paths)?;
+
+        let loaded = load_claims_for_scenario(
+            &repo_root,
+            template.id,
+            cli_args.claims_path.as_deref(),
+            thresholds,
+        )?;
+        claims_source_path = Some(loaded.source_path.clone());
+        loaded_claims = loaded.claims;
+
+        ensure_no_stale_processes(template.stale_process_signatures).await?;
+
+        if template.requires_docker {
+            assert_command_success(
+                run_shell_command(&repo_root, &repo_root, "docker --version", true).await?,
+                "docker --version",
+            )?;
+            assert_command_success(
+                run_shell_command(&repo_root, &repo_root, "docker compose version", true).await?,
+                "docker compose version",
+            )?;
+        }
+
+        if template.requires_vsomeip_runtime {
+            vsomeip_runtime_lib = Some(env::detect_vsomeip_runtime_lib(&repo_root)?);
+        }
+
+        if !cli_args.skip_build {
+            for build_command in template.build_commands {
+                let outcome =
+                    run_shell_command(&repo_root, &repo_root, build_command, cli_args.no_bootstrap)
+                        .await?;
+                assert_command_success(outcome, build_command)?;
+            }
+        }
+
+        Ok(())
+    })
+    .await;
+
+    if let Err(error) = preflight_result {
+        failure_reason = Some(error.to_string());
+    }
+
+    if failure_reason.is_none() {
+        let start_infra_result = execute_phase("StartInfra", &mut phase_timings, || async {
+            ensure_remaining_timeout(scenario_deadline, "StartInfra")?;
+
+            if template.requires_docker {
+                start_mqtt_broker(&repo_root, cli_args.no_bootstrap, scenario_deadline).await?;
+                mqtt_broker_started = true;
+            }
+
+            streamer_process = Some(
+                spawn_template_process(
+                    &repo_root,
+                    &artifact_dir,
+                    template,
+                    &template.streamer,
+                    &cli_args,
+                    vsomeip_runtime_lib.as_ref(),
+                )
+                .await?,
+            );
+
+            Ok(())
+        })
+        .await;
+
+        if let Err(error) = start_infra_result {
+            failure_reason = Some(error.to_string());
+        }
+    }
+
+    if failure_reason.is_none() {
+        let wait_streamer_ready_result =
+            execute_phase("WaitStreamerReady", &mut phase_timings, || async {
+                ensure_remaining_timeout(scenario_deadline, "WaitStreamerReady")?;
+
+                let streamer = streamer_process
+                    .as_ref()
+                    .ok_or_else(|| anyhow!("streamer process missing before readiness wait"))?;
+                let marker = template
+                    .streamer
+                    .readiness_marker
+                    .ok_or_else(|| anyhow!("streamer readiness marker not configured"))?;
+
+                let marker_timeout = Duration::from_secs(
+                    template
+                        .streamer
+                        .readiness_timeout_secs
+                        .unwrap_or(env::STREAMER_READY_TIMEOUT_SECS),
+                );
+                let timeout = min(
+                    marker_timeout,
+                    ensure_remaining_timeout(scenario_deadline, "WaitStreamerReady")?,
+                );
+
+                logs::wait_for_exact_marker(
+                    &streamer.log_path,
+                    marker,
+                    timeout,
+                    Duration::from_millis(env::LOG_POLL_INTERVAL_MS),
+                )
+                .await?;
+
+                Ok(())
+            })
+            .await;
+
+        if let Err(error) = wait_streamer_ready_result {
+            failure_reason = Some(error.to_string());
+        }
+    }
+
+    if failure_reason.is_none() {
+        let start_passive_result = execute_phase("StartPassive", &mut phase_timings, || async {
+            ensure_remaining_timeout(scenario_deadline, "StartPassive")?;
+
+            passive_process = Some(
+                spawn_template_process(
+                    &repo_root,
+                    &artifact_dir,
+                    template,
+                    &template.passive,
+                    &cli_args,
+                    vsomeip_runtime_lib.as_ref(),
+                )
+                .await?,
+            );
+
+            Ok(())
+        })
+        .await;
+
+        if let Err(error) = start_passive_result {
+            failure_reason = Some(error.to_string());
+        }
+    }
+
+    if failure_reason.is_none() {
+        let wait_passive_ready_result =
+            execute_phase("WaitPassiveReady", &mut phase_timings, || async {
+                ensure_remaining_timeout(scenario_deadline, "WaitPassiveReady")?;
+
+                let passive = passive_process
+                    .as_ref()
+                    .ok_or_else(|| anyhow!("passive process missing before readiness wait"))?;
+                let marker = template
+                    .passive
+                    .readiness_marker
+                    .ok_or_else(|| anyhow!("passive readiness marker not configured"))?;
+
+                let marker_timeout = Duration::from_secs(
+                    template
+                        .passive
+                        .readiness_timeout_secs
+                        .unwrap_or(env::PASSIVE_READY_TIMEOUT_SECS),
+                );
+                let timeout = min(
+                    marker_timeout,
+                    ensure_remaining_timeout(scenario_deadline, "WaitPassiveReady")?,
+                );
+
+                logs::wait_for_exact_marker(
+                    &passive.log_path,
+                    marker,
+                    timeout,
+                    Duration::from_millis(env::LOG_POLL_INTERVAL_MS),
+                )
+                .await?;
+
+                Ok(())
+            })
+            .await;
+
+        if let Err(error) = wait_passive_ready_result {
+            failure_reason = Some(error.to_string());
+        }
+    }
+
+    if failure_reason.is_none() {
+        let start_active_result = execute_phase("StartActive", &mut phase_timings, || async {
+            ensure_remaining_timeout(scenario_deadline, "StartActive")?;
+
+            active_process = Some(
+                spawn_template_process(
+                    &repo_root,
+                    &artifact_dir,
+                    template,
+                    &template.active,
+                    &cli_args,
+                    vsomeip_runtime_lib.as_ref(),
+                )
+                .await?,
+            );
+
+            let active = active_process
+                .as_mut()
+                .ok_or_else(|| anyhow!("active process missing after spawn"))?;
+            let remaining = ensure_remaining_timeout(scenario_deadline, "StartActive")?;
+            let exited = active.wait_with_timeout(remaining).await?;
+            if !exited {
+                return Err(anyhow!(
+                    "scenario hard timeout reached while waiting for bounded active sender completion"
+                ));
+            }
+
+            if active.exit_status_code != Some(0) {
+                return Err(anyhow!(
+                    "active process '{}' exited with status {:?}",
+                    active.name,
+                    active.exit_status_code
+                ));
+            }
+
+            Ok(())
+        })
+        .await;
+
+        if let Err(error) = start_active_result {
+            failure_reason = Some(error.to_string());
+        }
+    }
+
+    if failure_reason.is_none() {
+        let validate_claims_result =
+            execute_phase("ValidateClaims", &mut phase_timings, || async {
+                ensure_remaining_timeout(scenario_deadline, "ValidateClaims")?;
+
+                if loaded_claims.is_empty() {
+                    return Err(anyhow!(
+                        "no claims were loaded before validation for scenario '{}'",
+                        template.id
+                    ));
+                }
+
+                let outcomes = evaluate_claims(&artifact_dir, &loaded_claims);
+                let (must_outcomes, forbidden_outcomes, first_failed_claim_reason) =
+                    split_claim_outcomes(outcomes);
+
+                claim_outcomes = must_outcomes;
+                forbidden_claim_outcomes = forbidden_outcomes;
+
+                let streamer = streamer_process
+                    .as_ref()
+                    .ok_or_else(|| anyhow!("streamer process missing during claim validation"))?;
+                let passive = passive_process
+                    .as_ref()
+                    .ok_or_else(|| anyhow!("passive process missing during claim validation"))?;
+
+                let streamer_marker_count =
+                    logs::count_exact_marker(&streamer.log_path, env::READY_STREAMER_INITIALIZED)?;
+                if streamer_marker_count != 1 {
+                    return Err(anyhow!(
+                        "streamer readiness marker '{}' observed {} times (expected exactly 1)",
+                        env::READY_STREAMER_INITIALIZED,
+                        streamer_marker_count
+                    ));
+                }
+
+                let passive_marker_count =
+                    logs::count_exact_marker(&passive.log_path, env::READY_LISTENER_REGISTERED)?;
+                if passive_marker_count != 1 {
+                    return Err(anyhow!(
+                        "passive readiness marker '{}' observed {} times (expected exactly 1)",
+                        env::READY_LISTENER_REGISTERED,
+                        passive_marker_count
+                    ));
+                }
+
+                if let Some(first_failed_claim_reason) = first_failed_claim_reason {
+                    return Err(anyhow!(first_failed_claim_reason));
+                }
+
+                Ok(())
+            })
+            .await;
+
+        if let Err(error) = validate_claims_result {
+            failure_reason = Some(error.to_string());
+        }
+    }
+
+    let teardown_result = execute_phase("Teardown", &mut phase_timings, || async {
+        if let Some(active) = active_process.as_mut() {
+            active
+                .terminate_gracefully(
+                    Duration::from_secs(env::SIGINT_GRACE_SECS),
+                    Duration::from_secs(env::SIGTERM_GRACE_SECS),
+                )
+                .await?;
+        }
+
+        if let Some(passive) = passive_process.as_mut() {
+            passive
+                .terminate_gracefully(
+                    Duration::from_secs(env::SIGINT_GRACE_SECS),
+                    Duration::from_secs(env::SIGTERM_GRACE_SECS),
+                )
+                .await?;
+        }
+
+        if let Some(streamer) = streamer_process.as_mut() {
+            streamer
+                .terminate_gracefully(
+                    Duration::from_secs(env::SIGINT_GRACE_SECS),
+                    Duration::from_secs(env::SIGTERM_GRACE_SECS),
+                )
+                .await?;
+        }
+
+        if template.requires_docker && mqtt_broker_started {
+            stop_mqtt_broker(&repo_root, cli_args.no_bootstrap).await?;
+        }
+
+        ensure_process_exited(active_process.as_mut(), "active")?;
+        ensure_process_exited(passive_process.as_mut(), "passive")?;
+        ensure_process_exited(streamer_process.as_mut(), "streamer")?;
+
+        Ok(())
+    })
+    .await;
+
+    if failure_reason.is_none() {
+        if let Err(error) = teardown_result {
+            failure_reason = Some(error.to_string());
+        }
+    }
+
+    let finalize_report_result =
+        execute_phase("FinalizeReport", &mut phase_timings, || async { Ok(()) }).await;
+    if failure_reason.is_none() {
+        if let Err(error) = finalize_report_result {
+            failure_reason = Some(error.to_string());
+        }
+    }
+
+    let scenario_end_wall = Utc::now();
+    let scenario_duration_ms = scenario_start_instant.elapsed().as_millis();
+
+    let process_metadata =
+        gather_process_metadata(&streamer_process, &passive_process, &active_process);
+
+    let pass = failure_reason.is_none()
+        && claim_outcomes.iter().all(|outcome| outcome.pass)
+        && forbidden_claim_outcomes.iter().all(|outcome| outcome.pass);
+    let exit_code = if pass { 0 } else { 1 };
+
+    let repro_command = render_repro_command(template.id, &cli_args, &artifact_dir);
+
+    let scenario_report = ScenarioReport {
+        schema_version: report::SCENARIO_REPORT_SCHEMA_VERSION.to_string(),
+        scenario_id: template.id.to_string(),
+        transport_family: template.transport_family.as_str().to_string(),
+        pass,
+        exit_code,
+        phase_timings,
+        processes: process_metadata,
+        claim_outcomes,
+        forbidden_claim_outcomes,
+        failure_reason: failure_reason.clone(),
+        repro_command,
+        artifact_dir: artifact_dir.display().to_string(),
+        claims_source_path: claims_source_path
+            .as_ref()
+            .map(|path| path.display().to_string()),
+        start_ts: report::timestamp_to_string(scenario_start_wall),
+        end_ts: report::timestamp_to_string(scenario_end_wall),
+        duration_ms: scenario_duration_ms,
+    };
+
+    let (scenario_report_json, scenario_report_txt) =
+        report::write_scenario_report(&scenario_report, &artifact_dir)?;
+
+    println!("SCENARIO_ID={}", template.id);
+    println!(
+        "SCENARIO_STATUS={}",
+        if scenario_report.pass { "PASS" } else { "FAIL" }
+    );
+    println!("SCENARIO_ARTIFACT_DIR={}", artifact_dir.display());
+    println!("SCENARIO_REPORT_JSON={}", scenario_report_json.display());
+    println!(
+        "SCENARIO_CLAIMS_SOURCE_PATH={}",
+        scenario_report
+            .claims_source_path
+            .as_deref()
+            .unwrap_or("<not-resolved>")
+    );
+
+    Ok(ScenarioRunResult {
+        pass: scenario_report.pass,
+        exit_code,
+        artifact_dir,
+        scenario_report_json,
+        scenario_report_txt,
+        failure_reason,
+    })
+}
+
+fn render_repro_command(
+    scenario_id: &str,
+    cli_args: &ScenarioCliArgs,
+    artifact_dir: &Path,
+) -> String {
+    let mut args = vec![
+        "cargo run -p transport-smoke-suite --bin".to_string(),
+        scenario_id.to_string(),
+        "--".to_string(),
+        format!(
+            "--artifacts-root {}",
+            shell_escape(
+                artifact_dir
+                    .parent()
+                    .unwrap_or(artifact_dir)
+                    .display()
+                    .to_string()
+                    .as_str()
+            )
+        ),
+        format!("--send-count {}", cli_args.send_count),
+        format!("--send-interval-ms {}", cli_args.send_interval_ms),
+    ];
+
+    if cli_args.skip_build {
+        args.push("--skip-build".to_string());
+    }
+    if cli_args.no_bootstrap {
+        args.push("--no-bootstrap".to_string());
+    }
+    if let Some(claims_path) = &cli_args.claims_path {
+        args.push(format!(
+            "--claims-path {}",
+            shell_escape(claims_path.display().to_string().as_str())
+        ));
+    }
+    if let Some(expected_branch) = &cli_args.expected_branch {
+        args.push(format!(
+            "--expected-branch {}",
+            shell_escape(expected_branch)
+        ));
+    }
+    if let Some(scenario_timeout_secs) = cli_args.scenario_timeout_secs {
+        args.push(format!("--scenario-timeout-secs {}", scenario_timeout_secs));
+    }
+
+    args.join(" ")
+}
+
+fn gather_process_metadata(
+    streamer_process: &Option<ManagedProcess>,
+    passive_process: &Option<ManagedProcess>,
+    active_process: &Option<ManagedProcess>,
+) -> Vec<ProcessMetadata> {
+    [streamer_process, passive_process, active_process]
+        .into_iter()
+        .flatten()
+        .map(|process| ProcessMetadata {
+            name: process.name.clone(),
+            pid: process.pid,
+            process_group_id: process.process_group_id,
+            command: process.command_line.clone(),
+            workdir: process.workdir.display().to_string(),
+            log_file: process.log_path.display().to_string(),
+            exit_status: process.exit_status_code,
+        })
+        .collect()
+}
+
+fn ensure_process_exited(process: Option<&mut ManagedProcess>, role: &str) -> Result<()> {
+    let Some(process) = process else {
+        return Ok(());
+    };
+
+    if !process.has_exited() {
+        return Err(anyhow!(
+            "{} process '{}' remained alive after teardown",
+            role,
+            process.name
+        ));
+    }
+    Ok(())
+}
+
+async fn start_mqtt_broker(repo_root: &Path, no_bootstrap: bool, deadline: Instant) -> Result<()> {
+    let compose_path = repo_root
+        .join("utils")
+        .join("mosquitto")
+        .join("docker-compose.yaml");
+    let compose_path_quoted = shell_escape(compose_path.display().to_string().as_str());
+
+    let down_command = format!("docker compose -f {compose_path_quoted} down --remove-orphans");
+    let _ = run_shell_command(repo_root, repo_root, &down_command, no_bootstrap).await;
+
+    let up_command = format!("docker compose -f {compose_path_quoted} up -d");
+    let up_outcome = run_shell_command(repo_root, repo_root, &up_command, no_bootstrap).await?;
+    assert_command_success(up_outcome, "docker compose up -d")?;
+
+    let broker_deadline = Instant::now() + Duration::from_secs(env::BROKER_READY_TIMEOUT_SECS);
+    loop {
+        let poll_command =
+            format!("docker compose -f {compose_path_quoted} ps --status running --services");
+        let poll_outcome = run_shell_command(repo_root, repo_root, &poll_command, true).await?;
+        if poll_outcome.status_code == Some(0)
+            && poll_outcome
+                .stdout
+                .lines()
+                .any(|line| line.trim() == "mosquitto")
+        {
+            return Ok(());
+        }
+
+        if Instant::now() >= broker_deadline {
+            return Err(anyhow!(
+                "timed out waiting for MQTT broker readiness (stdout='{}', stderr='{}')",
+                poll_outcome.stdout.trim(),
+                poll_outcome.stderr.trim()
+            ));
+        }
+        if Instant::now() >= deadline {
+            return Err(anyhow!(
+                "scenario hard timeout reached while waiting for MQTT broker readiness"
+            ));
+        }
+
+        tokio::time::sleep(Duration::from_millis(env::LOG_POLL_INTERVAL_MS)).await;
+    }
+}
+
+async fn stop_mqtt_broker(repo_root: &Path, no_bootstrap: bool) -> Result<()> {
+    let compose_path = repo_root
+        .join("utils")
+        .join("mosquitto")
+        .join("docker-compose.yaml");
+    let compose_path_quoted = shell_escape(compose_path.display().to_string().as_str());
+    let down_command = format!("docker compose -f {compose_path_quoted} down --remove-orphans");
+
+    let outcome = run_shell_command(repo_root, repo_root, &down_command, no_bootstrap).await?;
+    assert_command_success(outcome, "docker compose down")
+}
+
+async fn spawn_template_process(
+    repo_root: &Path,
+    artifact_dir: &Path,
+    scenario_template: &ScenarioTemplate,
+    template: &ProcessTemplate,
+    cli_args: &ScenarioCliArgs,
+    vsomeip_runtime_lib: Option<&PathBuf>,
+) -> Result<ManagedProcess> {
+    let mut args = template
+        .args
+        .iter()
+        .map(|arg| arg.to_string())
+        .collect::<Vec<_>>();
+    if template.bounded_sender {
+        args.push("--send-count".to_string());
+        args.push(cli_args.send_count.to_string());
+        args.push("--send-interval-ms".to_string());
+        args.push(cli_args.send_interval_ms.to_string());
+    }
+
+    let mut env_pairs = template
+        .env
+        .iter()
+        .map(|(key, value)| (key.to_string(), value.to_string()))
+        .collect::<Vec<_>>();
+
+    if scenario_template.requires_vsomeip_runtime {
+        let runtime_lib = vsomeip_runtime_lib.ok_or_else(|| {
+            anyhow!("vsomeip runtime library was required but no path was resolved")
+        })?;
+        let existing_ld_library_path = std::env::var("LD_LIBRARY_PATH").unwrap_or_default();
+        let merged_ld_library_path = if existing_ld_library_path.is_empty() {
+            runtime_lib.display().to_string()
+        } else {
+            format!("{}:{existing_ld_library_path}", runtime_lib.display())
+        };
+        env_pairs.push(("LD_LIBRARY_PATH".to_string(), merged_ld_library_path));
+    }
+
+    let process_spec = ProcessSpec {
+        name: template.name.to_string(),
+        workdir: repo_root.join(template.workdir),
+        executable: repo_root.join("target").join("debug").join(template.binary),
+        args,
+        env: env_pairs,
+        log_file_name: template.log_file.to_string(),
+    };
+
+    ManagedProcess::spawn(process_spec, repo_root, artifact_dir, cli_args.no_bootstrap).await
+}
+
+async fn ensure_no_stale_processes(signatures: &[&str]) -> Result<()> {
+    if signatures.is_empty() {
+        return Ok(());
+    }
+
+    let pattern = signatures.join("|");
+    let output = tokio::process::Command::new("pgrep")
+        .arg("-fa")
+        .arg(&pattern)
+        .output()
+        .await
+        .context("failed to run stale-process preflight check")?;
+
+    if output.status.code() == Some(1) {
+        return Ok(());
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if !stdout.is_empty() {
+        return Err(anyhow!(
+            "stale process check failed; matching processes still running: {}",
+            stdout
+        ));
+    }
+
+    Err(anyhow!(
+        "stale process check failed with status {:?}: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    ))
+}
+
+fn assert_command_success(outcome: crate::process::CommandOutcome, label: &str) -> Result<()> {
+    if outcome.status_code == Some(0) {
+        return Ok(());
+    }
+
+    Err(anyhow!(
+        "{} failed (status={:?})\ncommand: {}\nstdout:\n{}\nstderr:\n{}",
+        label,
+        outcome.status_code,
+        outcome.command,
+        outcome.stdout,
+        outcome.stderr
+    ))
+}
+
+fn ensure_remaining_timeout(deadline: Instant, phase: &str) -> Result<Duration> {
+    deadline
+        .checked_duration_since(Instant::now())
+        .ok_or_else(|| anyhow!("scenario hard timeout reached in phase '{phase}'"))
+}
+
+async fn execute_phase<F, Fut>(
+    phase_name: &str,
+    phase_timings: &mut Vec<PhaseTiming>,
+    f: F,
+) -> Result<()>
+where
+    F: FnOnce() -> Fut,
+    Fut: std::future::Future<Output = Result<()>>,
+{
+    let phase_start_wall = Utc::now();
+    let phase_start_instant = Instant::now();
+    let result = f().await;
+    let phase_end_wall = Utc::now();
+
+    phase_timings.push(PhaseTiming {
+        phase: phase_name.to_string(),
+        start_ts: report::timestamp_to_string(phase_start_wall),
+        end_ts: report::timestamp_to_string(phase_end_wall),
+        duration_ms: phase_start_instant.elapsed().as_millis(),
+    });
+
+    result
+}
+
+pub fn scenario_ids_for_transport(transport_family: TransportFamily) -> Vec<&'static str> {
+    SCENARIO_IDS
+        .iter()
+        .copied()
+        .filter(|scenario_id| {
+            scenario_template(scenario_id)
+                .map(|template| template.transport_family == transport_family)
+                .unwrap_or(false)
+        })
+        .collect()
+}

--- a/utils/transport-smoke-suite/tests/fixture_audit.rs
+++ b/utils/transport-smoke-suite/tests/fixture_audit.rs
@@ -1,0 +1,66 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+use std::path::PathBuf;
+use transport_smoke_suite::claims::{evaluate_claims, load_claims_for_scenario, Thresholds};
+use transport_smoke_suite::env;
+use transport_smoke_suite::scenario;
+
+#[test]
+fn pass_fixtures_satisfy_scenario_claims() {
+    let repo_root = env::repo_root().expect("resolve workspace root");
+
+    for scenario_id in scenario::scenario_ids() {
+        let loaded = load_claims_for_scenario(&repo_root, scenario_id, None, Thresholds::default())
+            .unwrap_or_else(|_| panic!("unable to load claims for {}", scenario_id));
+        let fixture_dir = fixture_root().join(scenario_id).join("pass");
+        let outcomes = evaluate_claims(&fixture_dir, &loaded.claims);
+
+        let failed = outcomes
+            .into_iter()
+            .filter(|outcome| !outcome.pass)
+            .collect::<Vec<_>>();
+        assert!(
+            failed.is_empty(),
+            "pass fixture failed for {} with {:?}",
+            scenario_id,
+            failed
+        );
+    }
+}
+
+#[test]
+fn fail_fixtures_trigger_claim_failures() {
+    let repo_root = env::repo_root().expect("resolve workspace root");
+
+    for scenario_id in scenario::scenario_ids() {
+        let loaded = load_claims_for_scenario(&repo_root, scenario_id, None, Thresholds::default())
+            .unwrap_or_else(|_| panic!("unable to load claims for {}", scenario_id));
+        let fixture_dir = fixture_root()
+            .join(scenario_id)
+            .join("fail-missing-egress-ok");
+        let outcomes = evaluate_claims(&fixture_dir, &loaded.claims);
+
+        assert!(
+            outcomes.iter().any(|outcome| !outcome.pass),
+            "expected at least one failing claim for {}",
+            scenario_id
+        );
+    }
+}
+
+fn fixture_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+}

--- a/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-mqtt-ps-mqtt-publisher-zenoh-subscriber/fail-missing-egress-ok/publisher.log
+++ b/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-mqtt-ps-mqtt-publisher-zenoh-subscriber/fail-missing-egress-ok/publisher.log
@@ -1,0 +1,4 @@
+Sending Publish message
+Sending Publish message
+Sending Publish message
+Sending Publish message

--- a/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-mqtt-ps-mqtt-publisher-zenoh-subscriber/fail-missing-egress-ok/streamer.log
+++ b/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-mqtt-ps-mqtt-publisher-zenoh-subscriber/fail-missing-egress-ok/streamer.log
@@ -1,0 +1,3 @@
+event=egress_worker_create route_label=route-a
+event=egress_send_attempt
+event=egress_send_attempt

--- a/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-mqtt-ps-mqtt-publisher-zenoh-subscriber/fail-missing-egress-ok/subscriber.log
+++ b/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-mqtt-ps-mqtt-publisher-zenoh-subscriber/fail-missing-egress-ok/subscriber.log
@@ -1,0 +1,4 @@
+PublishReceiver: Received a message
+PublishReceiver: Received a message
+PublishReceiver: Received a message
+PublishReceiver: Received a message

--- a/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-mqtt-ps-mqtt-publisher-zenoh-subscriber/pass/publisher.log
+++ b/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-mqtt-ps-mqtt-publisher-zenoh-subscriber/pass/publisher.log
@@ -1,0 +1,4 @@
+Sending Publish message
+Sending Publish message
+Sending Publish message
+Sending Publish message

--- a/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-mqtt-ps-mqtt-publisher-zenoh-subscriber/pass/streamer.log
+++ b/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-mqtt-ps-mqtt-publisher-zenoh-subscriber/pass/streamer.log
@@ -1,0 +1,5 @@
+event=egress_worker_create route_label=route-a
+event=egress_send_attempt
+event=egress_send_ok
+event=egress_send_attempt
+event=egress_send_ok

--- a/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-mqtt-ps-mqtt-publisher-zenoh-subscriber/pass/subscriber.log
+++ b/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-mqtt-ps-mqtt-publisher-zenoh-subscriber/pass/subscriber.log
@@ -1,0 +1,4 @@
+PublishReceiver: Received a message
+PublishReceiver: Received a message
+PublishReceiver: Received a message
+PublishReceiver: Received a message

--- a/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-mqtt-ps-zenoh-publisher-mqtt-subscriber/fail-missing-egress-ok/publisher.log
+++ b/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-mqtt-ps-zenoh-publisher-mqtt-subscriber/fail-missing-egress-ok/publisher.log
@@ -1,0 +1,4 @@
+Sending Publish message
+Sending Publish message
+Sending Publish message
+Sending Publish message

--- a/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-mqtt-ps-zenoh-publisher-mqtt-subscriber/fail-missing-egress-ok/streamer.log
+++ b/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-mqtt-ps-zenoh-publisher-mqtt-subscriber/fail-missing-egress-ok/streamer.log
@@ -1,0 +1,3 @@
+event=egress_worker_create route_label=route-a
+event=egress_send_attempt
+event=egress_send_attempt

--- a/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-mqtt-ps-zenoh-publisher-mqtt-subscriber/fail-missing-egress-ok/subscriber.log
+++ b/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-mqtt-ps-zenoh-publisher-mqtt-subscriber/fail-missing-egress-ok/subscriber.log
@@ -1,0 +1,4 @@
+PublishReceiver: Received a message
+PublishReceiver: Received a message
+PublishReceiver: Received a message
+PublishReceiver: Received a message

--- a/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-mqtt-ps-zenoh-publisher-mqtt-subscriber/pass/publisher.log
+++ b/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-mqtt-ps-zenoh-publisher-mqtt-subscriber/pass/publisher.log
@@ -1,0 +1,4 @@
+Sending Publish message
+Sending Publish message
+Sending Publish message
+Sending Publish message

--- a/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-mqtt-ps-zenoh-publisher-mqtt-subscriber/pass/streamer.log
+++ b/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-mqtt-ps-zenoh-publisher-mqtt-subscriber/pass/streamer.log
@@ -1,0 +1,5 @@
+event=egress_worker_create route_label=route-a
+event=egress_send_attempt
+event=egress_send_ok
+event=egress_send_attempt
+event=egress_send_ok

--- a/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-mqtt-ps-zenoh-publisher-mqtt-subscriber/pass/subscriber.log
+++ b/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-mqtt-ps-zenoh-publisher-mqtt-subscriber/pass/subscriber.log
@@ -1,0 +1,4 @@
+PublishReceiver: Received a message
+PublishReceiver: Received a message
+PublishReceiver: Received a message
+PublishReceiver: Received a message

--- a/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-mqtt-rr-mqtt-client-zenoh-service/fail-missing-egress-ok/client.log
+++ b/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-mqtt-rr-mqtt-client-zenoh-service/fail-missing-egress-ok/client.log
@@ -1,0 +1,5 @@
+ServiceResponseListener: Received a message
+UMESSAGE_TYPE_RESPONSE
+ServiceResponseListener: Received a message
+UMESSAGE_TYPE_RESPONSE
+commstatus: Some(OK)

--- a/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-mqtt-rr-mqtt-client-zenoh-service/fail-missing-egress-ok/service.log
+++ b/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-mqtt-rr-mqtt-client-zenoh-service/fail-missing-egress-ok/service.log
@@ -1,0 +1,4 @@
+ServiceResponseListener: Received a message
+Sending Response message
+ServiceResponseListener: Received a message
+Sending Response message

--- a/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-mqtt-rr-mqtt-client-zenoh-service/fail-missing-egress-ok/streamer.log
+++ b/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-mqtt-rr-mqtt-client-zenoh-service/fail-missing-egress-ok/streamer.log
@@ -1,0 +1,3 @@
+event=egress_worker_create route_label=route-a
+event=egress_send_attempt
+event=egress_send_attempt

--- a/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-mqtt-rr-mqtt-client-zenoh-service/pass/client.log
+++ b/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-mqtt-rr-mqtt-client-zenoh-service/pass/client.log
@@ -1,0 +1,5 @@
+ServiceResponseListener: Received a message
+UMESSAGE_TYPE_RESPONSE
+ServiceResponseListener: Received a message
+UMESSAGE_TYPE_RESPONSE
+commstatus: Some(OK)

--- a/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-mqtt-rr-mqtt-client-zenoh-service/pass/service.log
+++ b/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-mqtt-rr-mqtt-client-zenoh-service/pass/service.log
@@ -1,0 +1,4 @@
+ServiceResponseListener: Received a message
+Sending Response message
+ServiceResponseListener: Received a message
+Sending Response message

--- a/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-mqtt-rr-mqtt-client-zenoh-service/pass/streamer.log
+++ b/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-mqtt-rr-mqtt-client-zenoh-service/pass/streamer.log
@@ -1,0 +1,5 @@
+event=egress_worker_create route_label=route-a
+event=egress_send_attempt
+event=egress_send_ok
+event=egress_send_attempt
+event=egress_send_ok

--- a/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-mqtt-rr-zenoh-client-mqtt-service/fail-missing-egress-ok/client.log
+++ b/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-mqtt-rr-zenoh-client-mqtt-service/fail-missing-egress-ok/client.log
@@ -1,0 +1,5 @@
+ServiceResponseListener: Received a message
+UMESSAGE_TYPE_RESPONSE
+ServiceResponseListener: Received a message
+UMESSAGE_TYPE_RESPONSE
+commstatus: Some(OK)

--- a/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-mqtt-rr-zenoh-client-mqtt-service/fail-missing-egress-ok/service.log
+++ b/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-mqtt-rr-zenoh-client-mqtt-service/fail-missing-egress-ok/service.log
@@ -1,0 +1,4 @@
+ServiceResponseListener: Received a message
+Sending Response message
+ServiceResponseListener: Received a message
+Sending Response message

--- a/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-mqtt-rr-zenoh-client-mqtt-service/fail-missing-egress-ok/streamer.log
+++ b/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-mqtt-rr-zenoh-client-mqtt-service/fail-missing-egress-ok/streamer.log
@@ -1,0 +1,3 @@
+event=egress_worker_create route_label=route-a
+event=egress_send_attempt
+event=egress_send_attempt

--- a/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-mqtt-rr-zenoh-client-mqtt-service/pass/client.log
+++ b/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-mqtt-rr-zenoh-client-mqtt-service/pass/client.log
@@ -1,0 +1,5 @@
+ServiceResponseListener: Received a message
+UMESSAGE_TYPE_RESPONSE
+ServiceResponseListener: Received a message
+UMESSAGE_TYPE_RESPONSE
+commstatus: Some(OK)

--- a/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-mqtt-rr-zenoh-client-mqtt-service/pass/service.log
+++ b/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-mqtt-rr-zenoh-client-mqtt-service/pass/service.log
@@ -1,0 +1,4 @@
+ServiceResponseListener: Received a message
+Sending Response message
+ServiceResponseListener: Received a message
+Sending Response message

--- a/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-mqtt-rr-zenoh-client-mqtt-service/pass/streamer.log
+++ b/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-mqtt-rr-zenoh-client-mqtt-service/pass/streamer.log
@@ -1,0 +1,5 @@
+event=egress_worker_create route_label=route-a
+event=egress_send_attempt
+event=egress_send_ok
+event=egress_send_attempt
+event=egress_send_ok

--- a/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-someip-ps-someip-publisher-zenoh-subscriber/fail-missing-egress-ok/publisher.log
+++ b/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-someip-ps-someip-publisher-zenoh-subscriber/fail-missing-egress-ok/publisher.log
@@ -1,0 +1,4 @@
+Sending Publish message
+Sending Publish message
+Sending Publish message
+Sending Publish message

--- a/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-someip-ps-someip-publisher-zenoh-subscriber/fail-missing-egress-ok/streamer.log
+++ b/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-someip-ps-someip-publisher-zenoh-subscriber/fail-missing-egress-ok/streamer.log
@@ -1,0 +1,3 @@
+event=egress_worker_create route_label=route-a
+event=egress_send_attempt
+event=egress_send_attempt

--- a/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-someip-ps-someip-publisher-zenoh-subscriber/fail-missing-egress-ok/subscriber.log
+++ b/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-someip-ps-someip-publisher-zenoh-subscriber/fail-missing-egress-ok/subscriber.log
@@ -1,0 +1,4 @@
+PublishReceiver: Received a message
+PublishReceiver: Received a message
+PublishReceiver: Received a message
+PublishReceiver: Received a message

--- a/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-someip-ps-someip-publisher-zenoh-subscriber/pass/publisher.log
+++ b/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-someip-ps-someip-publisher-zenoh-subscriber/pass/publisher.log
@@ -1,0 +1,4 @@
+Sending Publish message
+Sending Publish message
+Sending Publish message
+Sending Publish message

--- a/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-someip-ps-someip-publisher-zenoh-subscriber/pass/streamer.log
+++ b/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-someip-ps-someip-publisher-zenoh-subscriber/pass/streamer.log
@@ -1,0 +1,5 @@
+event=egress_worker_create route_label=route-a
+event=egress_send_attempt
+event=egress_send_ok
+event=egress_send_attempt
+event=egress_send_ok

--- a/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-someip-ps-someip-publisher-zenoh-subscriber/pass/subscriber.log
+++ b/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-someip-ps-someip-publisher-zenoh-subscriber/pass/subscriber.log
@@ -1,0 +1,4 @@
+PublishReceiver: Received a message
+PublishReceiver: Received a message
+PublishReceiver: Received a message
+PublishReceiver: Received a message

--- a/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-someip-ps-zenoh-publisher-someip-subscriber/fail-missing-egress-ok/publisher.log
+++ b/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-someip-ps-zenoh-publisher-someip-subscriber/fail-missing-egress-ok/publisher.log
@@ -1,0 +1,4 @@
+Sending Publish message
+Sending Publish message
+Sending Publish message
+Sending Publish message

--- a/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-someip-ps-zenoh-publisher-someip-subscriber/fail-missing-egress-ok/streamer.log
+++ b/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-someip-ps-zenoh-publisher-someip-subscriber/fail-missing-egress-ok/streamer.log
@@ -1,0 +1,3 @@
+event=egress_worker_create route_label=route-a
+event=egress_send_attempt
+event=egress_send_attempt

--- a/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-someip-ps-zenoh-publisher-someip-subscriber/fail-missing-egress-ok/subscriber.log
+++ b/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-someip-ps-zenoh-publisher-someip-subscriber/fail-missing-egress-ok/subscriber.log
@@ -1,0 +1,4 @@
+PublishReceiver: Received a message
+PublishReceiver: Received a message
+PublishReceiver: Received a message
+PublishReceiver: Received a message

--- a/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-someip-ps-zenoh-publisher-someip-subscriber/pass/publisher.log
+++ b/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-someip-ps-zenoh-publisher-someip-subscriber/pass/publisher.log
@@ -1,0 +1,4 @@
+Sending Publish message
+Sending Publish message
+Sending Publish message
+Sending Publish message

--- a/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-someip-ps-zenoh-publisher-someip-subscriber/pass/streamer.log
+++ b/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-someip-ps-zenoh-publisher-someip-subscriber/pass/streamer.log
@@ -1,0 +1,5 @@
+event=egress_worker_create route_label=route-a
+event=egress_send_attempt
+event=egress_send_ok
+event=egress_send_attempt
+event=egress_send_ok

--- a/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-someip-ps-zenoh-publisher-someip-subscriber/pass/subscriber.log
+++ b/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-someip-ps-zenoh-publisher-someip-subscriber/pass/subscriber.log
@@ -1,0 +1,4 @@
+PublishReceiver: Received a message
+PublishReceiver: Received a message
+PublishReceiver: Received a message
+PublishReceiver: Received a message

--- a/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-someip-rr-someip-client-zenoh-service/fail-missing-egress-ok/client.log
+++ b/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-someip-rr-someip-client-zenoh-service/fail-missing-egress-ok/client.log
@@ -1,0 +1,5 @@
+ServiceResponseListener: Received a message
+UMESSAGE_TYPE_RESPONSE
+ServiceResponseListener: Received a message
+UMESSAGE_TYPE_RESPONSE
+commstatus: Some(OK)

--- a/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-someip-rr-someip-client-zenoh-service/fail-missing-egress-ok/service.log
+++ b/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-someip-rr-someip-client-zenoh-service/fail-missing-egress-ok/service.log
@@ -1,0 +1,4 @@
+ServiceResponseListener: Received a message
+Sending Response message
+ServiceResponseListener: Received a message
+Sending Response message

--- a/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-someip-rr-someip-client-zenoh-service/fail-missing-egress-ok/streamer.log
+++ b/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-someip-rr-someip-client-zenoh-service/fail-missing-egress-ok/streamer.log
@@ -1,0 +1,3 @@
+event=egress_worker_create route_label=route-a
+event=egress_send_attempt
+event=egress_send_attempt

--- a/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-someip-rr-someip-client-zenoh-service/pass/client.log
+++ b/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-someip-rr-someip-client-zenoh-service/pass/client.log
@@ -1,0 +1,6 @@
+ServiceResponseListener: Received a message
+UMESSAGE_TYPE_RESPONSE
+ServiceResponseListener: Received a message
+UMESSAGE_TYPE_RESPONSE
+commstatus: Some(OK)
+UMESSAGE_TYPE_RESPONSE

--- a/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-someip-rr-someip-client-zenoh-service/pass/service.log
+++ b/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-someip-rr-someip-client-zenoh-service/pass/service.log
@@ -1,0 +1,4 @@
+ServiceResponseListener: Received a message
+Sending Response message
+ServiceResponseListener: Received a message
+Sending Response message

--- a/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-someip-rr-someip-client-zenoh-service/pass/streamer.log
+++ b/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-someip-rr-someip-client-zenoh-service/pass/streamer.log
@@ -1,0 +1,5 @@
+event=egress_worker_create route_label=route-a
+event=egress_send_attempt
+event=egress_send_ok
+event=egress_send_attempt
+event=egress_send_ok

--- a/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-someip-rr-zenoh-client-someip-service/fail-missing-egress-ok/client.log
+++ b/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-someip-rr-zenoh-client-someip-service/fail-missing-egress-ok/client.log
@@ -1,0 +1,5 @@
+ServiceResponseListener: Received a message
+UMESSAGE_TYPE_RESPONSE
+ServiceResponseListener: Received a message
+UMESSAGE_TYPE_RESPONSE
+commstatus: Some(OK)

--- a/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-someip-rr-zenoh-client-someip-service/fail-missing-egress-ok/service.log
+++ b/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-someip-rr-zenoh-client-someip-service/fail-missing-egress-ok/service.log
@@ -1,0 +1,4 @@
+ServiceResponseListener: Received a message
+Sending Response message
+ServiceResponseListener: Received a message
+Sending Response message

--- a/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-someip-rr-zenoh-client-someip-service/fail-missing-egress-ok/streamer.log
+++ b/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-someip-rr-zenoh-client-someip-service/fail-missing-egress-ok/streamer.log
@@ -1,0 +1,3 @@
+event=egress_worker_create route_label=route-a
+event=egress_send_attempt
+event=egress_send_attempt

--- a/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-someip-rr-zenoh-client-someip-service/pass/client.log
+++ b/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-someip-rr-zenoh-client-someip-service/pass/client.log
@@ -1,0 +1,5 @@
+ServiceResponseListener: Received a message
+UMESSAGE_TYPE_RESPONSE
+ServiceResponseListener: Received a message
+UMESSAGE_TYPE_RESPONSE
+commstatus: Some(OK)

--- a/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-someip-rr-zenoh-client-someip-service/pass/service.log
+++ b/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-someip-rr-zenoh-client-someip-service/pass/service.log
@@ -1,0 +1,4 @@
+ServiceResponseListener: Received a message
+Sending Response message
+ServiceResponseListener: Received a message
+Sending Response message

--- a/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-someip-rr-zenoh-client-someip-service/pass/streamer.log
+++ b/utils/transport-smoke-suite/tests/fixtures/smoke-zenoh-someip-rr-zenoh-client-someip-service/pass/streamer.log
@@ -1,0 +1,5 @@
+event=egress_worker_create route_label=route-a
+event=egress_send_attempt
+event=egress_send_ok
+event=egress_send_attempt
+event=egress_send_ok

--- a/utils/transport-smoke-suite/tests/scenario_contracts.rs
+++ b/utils/transport-smoke-suite/tests/scenario_contracts.rs
@@ -1,0 +1,67 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+use transport_smoke_suite::claims::{
+    default_claims_file_path, load_claims_for_scenario, ClaimCategory, Thresholds,
+};
+use transport_smoke_suite::env;
+use transport_smoke_suite::scenario;
+
+#[test]
+fn scenario_registry_contains_exactly_eight_ids() {
+    let scenario_ids = scenario::scenario_ids();
+    assert_eq!(scenario_ids.len(), 8);
+}
+
+#[test]
+fn each_scenario_has_claims_file_with_required_category_coverage() {
+    let repo_root = env::repo_root().expect("resolve workspace root");
+
+    for scenario_id in scenario::scenario_ids() {
+        let claims_path = default_claims_file_path(&repo_root, scenario_id);
+        assert!(
+            claims_path.is_file(),
+            "missing claims file for {} at {}",
+            scenario_id,
+            claims_path.display()
+        );
+
+        let loaded = load_claims_for_scenario(&repo_root, scenario_id, None, Thresholds::default())
+            .unwrap_or_else(|_| panic!("unable to load claims for {}", scenario_id));
+
+        assert!(
+            loaded
+                .claims
+                .iter()
+                .any(|claim| claim.category == ClaimCategory::EndpointCommunication),
+            "{} claims file must include endpoint communication coverage",
+            claims_path.display()
+        );
+        assert!(
+            loaded
+                .claims
+                .iter()
+                .any(|claim| claim.category == ClaimCategory::StreamerEgress),
+            "{} claims file must include streamer egress coverage",
+            claims_path.display()
+        );
+        assert!(
+            loaded
+                .claims
+                .iter()
+                .any(|claim| claim.category == ClaimCategory::ForbiddenSignature),
+            "{} claims file must include forbidden signature coverage",
+            claims_path.display()
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Stacked increment for smoke scope; contains smoke-suite scope equivalent to c5 with deterministic scenario claims, matrix runner, smoke CI workflow, and deferred `example-streamer-uses` readiness/sender controls.
- Finalize workspace/example logging migration for smoke binaries (`tracing-subscriber` adoption and `log`/`env_logger` removal).
- Include fixture-backed smoke assertions under `utils/transport-smoke-suite/tests/fixtures`.
- Close R5 in this commit by adding `.gitattributes` linguist collapsing rules for smoke fixtures and claims.

## Stack Context
- Current PR: #85 (smoke layer)
- Target branch: `main`
- Depends on: #84 (transitively #83)
- Review order: #83 -> #84 -> #85
- Incremental review scope: compare against PR #84 to isolate smoke-only additions.

## SHA note (linear stack topology)
- PR #85 branch commit: `8011c08`
- This commit is rebased onto the benchmark layer to preserve true linear stacking.

## Validation
- PASS: `source build/envsetup.sh highest && cargo check --workspace --all-targets`
- PASS: `source build/envsetup.sh highest && cargo check -p transport-smoke-suite --all-targets`
- PASS: `source build/envsetup.sh highest && cargo test -p transport-smoke-suite --tests`
- PASS: `source build/envsetup.sh highest && cargo test --workspace`
- PASS: `source build/envsetup.sh highest && cargo clippy --all-targets -- -W warnings -D warnings`
- PASS: `source build/envsetup.sh highest && env -u VSOMEIP_INSTALL_PATH cargo clippy --features vsomeip-transport,bundled-vsomeip,zenoh-transport,mqtt-transport --all-targets -- -W warnings -D warnings`
- SKIP (environment): unbundled clippy because `VSOMEIP_INSTALL_PATH` is unset/invalid after `source build/envsetup.sh highest`